### PR TITLE
iOS7 compatibility

### DIFF
--- a/WootricSDK/WootricSDKObjC/WTRSurveyViewController+Utils.m
+++ b/WootricSDK/WootricSDKObjC/WTRSurveyViewController+Utils.m
@@ -42,8 +42,20 @@
 }
 
 - (BOOL)isSmallerScreenDevice {
+  // 'nativeBounds' only available on iOS 8.0+.
+  CGRect nativeBounds = CGRectZero;
+
+  if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)]) {
+    nativeBounds = [[UIScreen mainScreen] nativeBounds];
+  } else {
+    nativeBounds = [[UIScreen mainScreen] bounds];
+    CGFloat scale = [[UIScreen mainScreen] scale];
+    nativeBounds = CGRectMake(0.0, 0.0,
+                              nativeBounds.size.width * scale, nativeBounds.size.height * scale);
+  }
+
   // < iPhone 6 + iPhone 6 in "Zoomed Display"
-  if ([[UIScreen mainScreen] nativeBounds].size.height <= 1136 ||
+  if (nativeBounds.size.height <= 1136 ||
       [UIScreen mainScreen].currentMode.size.height <= 1136) {
     return YES;
   }

--- a/WootricSDK/WootricSDKObjC/WTRSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDKObjC/WTRSurveyViewController+Views.m
@@ -72,7 +72,7 @@
 
 - (void)setupBackButton {
   self.backButton = [[UIButton alloc] init];
-  UIImage *image = [UIImage imageNamed:@"icon_back_arrow" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+  UIImage *image = [UIImage imageNamed:@"icon_back_arrow"];
   UIImageView *backIcon = [[UIImageView alloc] initWithFrame:CGRectMake(8, 3, 16, 16)];
   backIcon.image = image;
   self.backButton.hidden = YES;
@@ -114,7 +114,7 @@
 
 - (void)setupDismissButton {
   self.dismissButton = [[UIButton alloc] init];
-  UIImage *image = [UIImage imageNamed:@"icon_close_round_grey" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+  UIImage *image = [UIImage imageNamed:@"icon_close_round_grey"];
   self.dismissImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 8, 16, 16)];
   self.dismissImageView.image = image;
   self.dismissImageView.tintColor = [UIColor whiteColor];
@@ -257,16 +257,14 @@
 #pragma mark - Icons
 
 - (void)setupButtonCheckIcon {
-  UIImage *checkIcon = [UIImage imageNamed:@"icon_check_disabled"
-                                  inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+  UIImage *checkIcon = [UIImage imageNamed:@"icon_check_disabled"];
   self.buttonIconCheck = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 16, 16)];
   self.buttonIconCheck.image = checkIcon;
   [self.buttonIconCheck setTranslatesAutoresizingMaskIntoConstraints:NO];
 }
 
 - (void)setupButtonSendIcon {
-  UIImage *sendIcon = [UIImage imageNamed:@"icon_send_arrow"
-                                 inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+  UIImage *sendIcon = [UIImage imageNamed:@"icon_send_arrow"];
   self.buttonIconSend = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 16, 16)];
   self.buttonIconSend.image = sendIcon;
   self.buttonIconSend.hidden = YES;

--- a/WootricSDK/WootricSDKObjC/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDKObjC/WTRSurveyViewController.m
@@ -262,9 +262,7 @@
 }
 
 - (void)firstTimeSliderTap {
-  UIImage *iconCheckEnabled = [UIImage imageNamed:@"icon_check_enabled"
-                                         inBundle:[NSBundle bundleForClass: [self class]]
-                    compatibleWithTraitCollection:nil];
+  UIImage *iconCheckEnabled = [UIImage imageNamed:@"icon_check_enabled"];
   _buttonIconCheck.image = iconCheckEnabled;
   _submitButton.enabled = YES;
   _dragToChangeLabel.hidden = NO;
@@ -353,9 +351,7 @@
   _sendFeedbackButton.enabled = NO;
   _dismissButton.enabled = NO;
   _commentTextView.editable = NO;
-  UIImage *sendArrowDisabled = [UIImage imageNamed:@"icon_send_arrow_disabled"
-                                          inBundle:[NSBundle bundleForClass:[self class]]
-                     compatibleWithTraitCollection:nil];
+  UIImage *sendArrowDisabled = [UIImage imageNamed:@"icon_send_arrow_disabled"];
   _buttonIconSend.image = sendArrowDisabled;
   NSString *text = nil;
   if ([_commentTextView.text length] != 0) {


### PR DESCRIPTION
This pull request contains some iOS7 compatibility fixes. In fact, the app using the SDK was crashing when the Wootric SDK tried to present the NPS ViewController due to the methods `-nativeBounds` on `UIScreen` and `+imageNamed:inBundle:compatibleWithTraitCollection:` on `UIImage` were iOS8+ only.

The fix for `+imageNamed:inBundle:compatibleWithTraitCollection:` is to simply use `imageNamed:` as cocoapods takes care of the images already.

The fix for `-nativeBounds` contains a `respondsToSelector` switch: Every device that doesn't support this method is obviously running iOS7 and before iOS8 (iPhone 6 and 6+) the pendant to the 'nativeBounds' is the bounds (multiplied with the current scale) as far as I know.

Tested on iOS7 (iPhone 4s) and iOS8 (iPhone 6 and 6+).

Please let me know if you have any issues w/ the Pull Request. For the time being, we're using my fork of the cocoapod.
