### PR TITLE
Followup placeholder bug fixed

### DIFF
--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -78,7 +78,6 @@
 
 - (void)setFeedbackPlaceholderText:(NSString *)text {
   _feedbackPlaceholder.text = text;
-  [_feedbackPlaceholder sizeToFit];
 }
 
 - (NSString *)feedbackText {


### PR DESCRIPTION
sizeToFit was messing with the placeholder layout when going back and forth from WTRScoreView to WTRFeedbackView
