### PR TITLE
Check response type

### DIFF
--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -90,23 +90,26 @@
             NSLog(@"WootricSDK (GET end user): %@", error);
         }
         else {
-            NSArray *responseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+          id responseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+          if ([responseJSON isKindOfClass:[NSArray class]]) {
             if ([responseJSON count] == 0) {
-                [self createEndUser:^(NSInteger endUserID) {
-                    endUserWithID(endUserID);
-                }];
-            }
-            else {
-                NSDictionary *endUser = responseJSON[0];
-                
-                if (endUser[@"id"]) {
-                    NSInteger endUserID = [endUser[@"id"] integerValue];
-                    if (!_endUserAlreadyUpdated) {
-                        [self updateExistingEndUser:endUserID];
-                    }
-                    endUserWithID(endUserID);
+              [self createEndUser:^(NSInteger endUserID) {
+                endUserWithID(endUserID);
+              }];
+            } else {
+              NSDictionary *endUser = responseJSON[0];
+              
+              if (endUser[@"id"]) {
+                NSInteger endUserID = [endUser[@"id"] integerValue];
+                if (!_endUserAlreadyUpdated) {
+                  [self updateExistingEndUser:endUserID];
                 }
+                endUserWithID(endUserID);
+              }
             }
+          } else {
+            NSLog(@"WootricSDK - Error: %@", responseJSON);
+          }
         }
     }];
     
@@ -161,7 +164,7 @@
     }
     
     if (_settings.customProperties) {
-        NSString *parsedProperties = [WTRPropertiesParser parseToStringFromDictionary:_settings.customProperties];;
+        NSString *parsedProperties = [WTRPropertiesParser parseToStringFromDictionary:_settings.customProperties];
         params = [NSString stringWithFormat:@"%@%@", params, parsedProperties];
     }
     


### PR DESCRIPTION
Check response type to see if the value returned by server is an array.

This bug seems to be related to the one we had with the AndroidSDK one month ago:
https://github.com/Wootric/WootricSDK-Android/pull/21

Both happen on getEndUserWithEmail and both on trying to get a JSON from the response array. 

Crash reported by client is this:
`Fatal Exception: NSInvalidArgumentException
-[__NSCFDictionary objectAtIndexedSubscript:]: unrecognized selector sent to instance 0x14ed53390`

and it happen on line 100 of WTRApiClient.m

`NSDictionary *endUser = responseJSON[0];`

What is happening here is that `responseJSON[0]` is trying to get a Dictionary object at index 0. It crashes because `responseJSON` is not an array, it's a Dictionary. Is there any circumstance in which `/api/v1/end_users?email` will not respond with an array?

More info:
Objective-C, under the hood, transforms `responseJSON[0]` to something like this `[responseJSON objectAtIndexedSubscript:0]`. `objectAtIndexedSubscript` is a method of the NSArray class.
The error message is telling us of "unrecognized selector sent to instance 0x14ed53390" Which means that `__NSCFDictionary` doesn't recognize this method, since it's a dictionary.

NSArray objectAtIndexedSubscript:
https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSArray_Class/#//apple_ref/occ/instm/NSArray/objectAtIndexedSubscript:
