### PR TITLE
Concurrent Survey Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.3 (2016-05-23)
+
+### Add:
+
+- Concurrent Survey Processing
+
 ## 0.5.2 (2016-03-31)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ gem install cocoapods
 ```
 To integrate WootricSDK into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```ruby
-pod "WootricSDK", "~> 0.5.2"
+pod "WootricSDK", "~> 0.5.3"
 ```
 Then, run the following command:
 

--- a/WootricSDK-Demo/WootricSDK-Demo.xcodeproj/project.pbxproj
+++ b/WootricSDK-Demo/WootricSDK-Demo.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 				TargetAttributes = {
 					B2DC6ECE1B81E5D800F599B3 = {
 						CreatedOnToolsVersion = 6.3.2;
+						DevelopmentTeam = 2S3B4KGAHN;
 					};
 					B2DC6EE71B81E5D800F599B3 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -430,11 +431,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "WootricSDK-Demo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -443,11 +447,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "WootricSDK-Demo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};

--- a/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
+++ b/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
@@ -16,24 +16,23 @@
 @implementation ViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    self.view.backgroundColor = [UIColor colorWithRed:58.0/255.0 green:57.0/255.0 blue:57.0/255.0 alpha:1];
-    
-    NSString *clientID = @"YOUR_CLIENT_ID";
-    NSString *clientSecret = @"YOUR_CLIENT_SECRET";
-    NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
-    
-    [Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
-    [Wootric setEndUserEmail:@"END_USER_EMAIL"];
-    [Wootric setEndUserCreatedAt:@1234567890];
-    
-    [Wootric forceSurvey:YES];
-    
-    [Wootric showSurveyInViewController:self];
+  [super viewDidLoad];
+  self.view.backgroundColor = [UIColor colorWithRed:58.0/255.0 green:57.0/255.0 blue:57.0/255.0 alpha:1];
+  NSString *clientID = @"YOUR_CLIENT_ID";
+  NSString *clientSecret = @"YOUR_CLIENT_SECRET";
+  NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
+  
+  [Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+  [Wootric setEndUserEmail:@"END_USER_EMAIL"];
+  [Wootric setEndUserCreatedAt:@1234567890];
+  
+  [Wootric forceSurvey:YES];
+  
+  [Wootric showSurveyInViewController:self];
 }
 
 - (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
+  [super didReceiveMemoryWarning];
 }
 
 @end

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.5.2'
+  s.version  = '0.5.3'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */; };
 		7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */; };
 		7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */; };
 		7E74E3391C8E99C300BCB84F /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7E74E3381C8E99C300BCB84F /* fontawesome-webfont.ttf */; };
@@ -108,6 +109,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRApiClientTests.m; sourceTree = "<group>"; };
 		7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FontAwesome.h"; sourceTree = "<group>"; };
 		7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FontAwesome.m"; sourceTree = "<group>"; };
 		7E74E3381C8E99C300BCB84F /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 				B29D63C91BC3CEEB00F0C98C /* WTRSettingsTests.m */,
 				B2DC6F141B81E6F900F599B3 /* WootricSDKTests.m */,
 				B2DC6F121B81E6F900F599B3 /* Supporting Files */,
+				0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */,
 			);
 			path = WootricSDKTests;
 			sourceTree = "<group>";
@@ -637,6 +640,7 @@
 				B29D63CA1BC3CEEB00F0C98C /* WTRSettingsTests.m in Sources */,
 				B2DC6F151B81E6F900F599B3 /* WootricSDKTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
+				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -123,7 +123,7 @@
 + (void)showSurveyInViewController:(UIViewController *)viewController {
     
     if ([[WTRApiClient sharedInstance] checkConfiguration]) {
-        
+      
         [WTRTrackingPixel getPixel];
         
         WTRSurvey *surveyClient = [[WTRSurvey alloc] init];

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -1,0 +1,206 @@
+//
+//  WTRApiClientTests.m
+//  WootricSDK
+//
+//  Created by Diego Serrano on 5/11/16.
+//  Copyright © 2016 Wootric. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "WTRApiClient.h"
+
+@interface WTRApiClientTests : XCTestCase
+
+@property (nonatomic, strong) WTRApiClient *apiClient;
+
+@end
+
+
+@interface WTRApiClient (Tests)
+
+@property (nonatomic, strong) NSString *baseAPIURL;
+@property (nonatomic, strong) NSString *surveyServerURL;
+@property (nonatomic, strong) NSString *accessToken;
+@property (nonatomic, strong) NSURLSession *wootricSession;
+@property (nonatomic, strong) NSNumber *userID;
+@property (nonatomic, strong) NSNumber *accountID;
+@property (nonatomic, strong) NSString *uniqueLink;
+@property (nonatomic, assign) BOOL endUserAlreadyUpdated;
+@property (nonatomic) int priority;
+
+- (NSMutableURLRequest *)requestWithURL:(NSURL *)url HTTPMethod:(NSString *)httpMethod andHTTPBody:(NSString *)httpBody;
+- (NSString *)percentEscapeString:(NSString *)string;
+- (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID;
+- (void)getEndUserWithEmail:(void (^)(NSInteger endUserID))endUserWithID;
+- (void)authenticate:(void (^)())authenticated;
+- (NSString *)paramsWithScore:(NSInteger)score endUserID:(long)endUserID userID:(NSNumber *)userID accountID:(NSNumber *)accountID uniqueLink:(nonnull NSString *)uniqueLink priority:(int)priority text:(nullable NSString *)text;
+- (NSString *)randomString;
+- (NSString *)buildUniqueLinkAccountToken:(NSString *)accountToken endUserEmail:(NSString *)endUserEmail date:(NSTimeInterval)date randomString:(NSString *)randomString;
+
+@end
+
+@implementation WTRApiClientTests
+
+- (void)setUp {
+  [super setUp];
+  
+  _apiClient = [WTRApiClient sharedInstance];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  _apiClient.settings.externalCreatedAt = nil;
+  _apiClient.settings.surveyImmediately = NO;
+  _apiClient.settings.firstSurveyAfter = @0;
+  _apiClient.priority = 0;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:NO forKey:@"surveyed"];
+  [defaults setDouble:0 forKey:@"lastSeenAt"];
+}
+
+-(void)testInstance {
+  XCTAssertNotNil(_apiClient, "WTRApiClient instance should not have been nil.");
+  
+  XCTAssertEqualObjects(_apiClient.baseAPIURL, @"https://api.wootric.com", @"baseAPIURL should have been equal to https://api.wootric.com");
+  
+  XCTAssertEqualObjects(_apiClient.surveyServerURL, @"https://survey.wootric.com/eligible.json", @"surveyServerURL should have been equal to https://survey.wootric.com/eligible.json");
+  
+  XCTAssertNotNil(_apiClient.wootricSession, "wootricSession should not have been nil.");
+  
+  XCTAssertNotNil(_apiClient.settings, "settings should not have been nil.");
+  
+  XCTAssertEqualObjects(_apiClient.apiVersion, @"api/v1", @"apiVersion should have been equal to api/v1");
+  
+  XCTAssertEqual(_apiClient.priority, 0, @"priority should have been equal to 0");
+}
+
+- (void)testCheckConfiguration {
+  
+  _apiClient.clientID = @"";
+  _apiClient.clientSecret = @"";
+  _apiClient.accountToken = @"";
+  
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"clientIDtestString";
+  _apiClient.clientSecret = @"clientSecretTestString";
+  _apiClient.accountToken = @"";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"";
+  _apiClient.clientSecret = @"clientSecretTestString";
+  _apiClient.accountToken = @"";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"";
+  _apiClient.clientSecret = @"";
+  _apiClient.accountToken = @"NPS-token";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"clientIDtestString";
+  _apiClient.clientSecret = @"clientSecretTestString";
+  _apiClient.accountToken = @"";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"clientIDtestString";
+  _apiClient.clientSecret = @"";
+  _apiClient.accountToken = @"NPS-token";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  
+  _apiClient.clientID = @"";
+  _apiClient.clientSecret = @"clientSecretTestString";
+  _apiClient.accountToken = @"NPS-token";
+  XCTAssertFalse([_apiClient checkConfiguration]);
+  
+  _apiClient.clientID = @"clientIDtestString";
+  _apiClient.clientSecret = @"clientSecretTestString";
+  _apiClient.accountToken = @"NPS-token";
+  XCTAssertTrue([_apiClient checkConfiguration]);
+}
+
+- (void)testRandomStringLength {
+  XCTAssertEqual([[_apiClient randomString] length], 16);
+}
+
+- (void)testBuildUniqueLink {
+  _apiClient.accountToken = @"testAccountToken";
+  _apiClient.settings.endUserEmail = @"test@example.com";
+  NSString *randomString = @"16charrandstring";
+  NSTimeInterval date = 1234567890;
+  
+  XCTAssertEqualObjects([_apiClient buildUniqueLinkAccountToken:_apiClient.accountToken
+                                            endUserEmail:_apiClient.settings.endUserEmail
+                                                    date:date
+                                            randomString:randomString],
+                 @"1ed9f1c96018e2d577b3f864dc59dffe2baccc7103f6dcdadc40c3b6ec98cb0b");
+}
+
+- (void)testResponseParams {
+  static NSString *expectedResponse = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0&score=9";
+  static NSString *expectedResponseAccountId = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0&score=9&account_id=1234";
+  
+  static NSString *expectedResponseAccountIdText = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0&score=9&text=test&account_id=1234";
+  
+  _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
+  NSInteger score = 9;
+  NSInteger endUserID = 12345678;
+  NSNumber *userID = nil;
+  NSNumber *accountID = nil;
+  NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
+  NSString *text = nil;
+  int priority = 0;
+  
+  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  XCTAssertEqualObjects(params, expectedResponse, "Should not have account_id nor text in params");
+  
+  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  XCTAssertEqualObjects(params, expectedResponse, "Should not have account_id nor text in params");
+  
+  accountID = @1234;
+  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  XCTAssertEqualObjects(params, expectedResponseAccountId);
+  
+  text = @"test";
+  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  XCTAssertEqualObjects(params, expectedResponseAccountIdText);
+}
+
+
+- (void)testDeclineParams {
+  static NSString *expectedResponse = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0";
+  static NSString *expectedResponseAccountId = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0&account_id=1234";
+  
+  _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
+  NSInteger endUserID = 12345678;
+  NSNumber *userID = nil;
+  NSNumber *accountID = nil;
+  NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
+  int priority = 0;
+  
+  NSString *params = [_apiClient paramsWithScore:-1 endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  XCTAssertEqualObjects(params, expectedResponse);
+  
+  accountID = @1234;
+  params = [_apiClient paramsWithScore:-1 endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  XCTAssertEqualObjects(params, expectedResponseAccountId);
+}
+
+- (void)testPriorityIncreases {
+  
+  _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
+  NSInteger score = 9;
+  NSInteger endUserID = 12345678;
+  NSNumber *userID = nil;
+  NSNumber *accountID = nil;
+  NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
+  _apiClient.priority = 0;
+  
+  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  XCTAssertEqual(_apiClient.priority, 1, "priority should be 1");
+  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  XCTAssertEqual(_apiClient.priority, 3, "priority should be 3");
+}
+
+@end

--- a/WootricSDK/WootricSDKTests/WootricSDKTests.m
+++ b/WootricSDK/WootricSDKTests/WootricSDKTests.m
@@ -1,4 +1,4 @@
-//
+ //
 //  WootricSDKTests.m
 //  WootricSDKTests
 //


### PR DESCRIPTION
Adds funcionality for CSP

https://trello.com/c/zgCyUiHl/204-3-concurrent-survey-process-step-3-ios-sdk

This commit:
- Includes end_user_id, user_id and unique_link on requests to responses and
  decline
- Creates unique_link algorithm to be a SHA256 hash of NPS token,
  end_user_email, date and a random string
- Adds priority number to responses and declines
- Adds WTRApiClientTests to test CSP changes

Code needed a refactor to make it more testable. I've focused on testing
the parts that involved CSP changes. There is still more testing to be
done but I prefered to leave that for another PR, atomic commits.

One thing I did include in this commit was changing identation of
ViewController.m and WTRApiClient.m from 4 spaces to 2. This is
and inconsistency throughout the project. I decided to settle for
2 spaces but haven't changed other files that use 4. Again, I'm
planning on doing this in a separate PR.

I've update the function to generate the unique link to use
a unix timestamp like date.

I've removed user_id test cases since it's no longer used.
