### PR TITLE
Color customization support for Segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 0.5.4 (2016-06-01)
+
+### Added:
+
+- Color customization support for Segment integration
+
 ## 0.5.3 (2016-05-23)
 
-### Add:
+### Added:
 
 - Concurrent Survey Processing
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ gem install cocoapods
 ```
 To integrate WootricSDK into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```ruby
-pod "WootricSDK", "~> 0.5.3"
+pod "WootricSDK", "~> 0.5.4"
 ```
 Then, run the following command:
 

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.5.3'
+  s.version  = '0.5.4'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
 		0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */; };
 		7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */; };
 		7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */; };
@@ -109,6 +110,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
 		0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRApiClientTests.m; sourceTree = "<group>"; };
 		7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FontAwesome.h"; sourceTree = "<group>"; };
 		7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FontAwesome.m"; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				B2DC6F141B81E6F900F599B3 /* WootricSDKTests.m */,
 				B2DC6F121B81E6F900F599B3 /* Supporting Files */,
 				0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */,
+				0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */,
 			);
 			path = WootricSDKTests;
 			sourceTree = "<group>";
@@ -638,6 +641,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B29D63CA1BC3CEEB00F0C98C /* WTRSettingsTests.m in Sources */,
+				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B2DC6F151B81E6F900F599B3 /* WootricSDKTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
 				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.2</string>
+	<string>0.5.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/SEGWootric.h
+++ b/WootricSDK/WootricSDK/SEGWootric.h
@@ -80,4 +80,9 @@
 
 - (void)setCustomValueForResurveyThrottle:(NSNumber *)resurveyThrottle visitorPercentage:(NSNumber *)visitorPercentage registeredPercentage:(NSNumber *)registeredPercentage dailyResponseCap:(NSNumber *)dailyResponseCap;
 
+- (void)setSendButtonBackgroundColor:(UIColor *)color;
+- (void)setSliderColor:(UIColor *)color;
+- (void)setThankYouButtonBackgroundColor:(UIColor *)color;
+- (void)setSocialSharingColor:(UIColor *)color;
+
 @end

--- a/WootricSDK/WootricSDK/SEGWootric.m
+++ b/WootricSDK/WootricSDK/SEGWootric.m
@@ -147,7 +147,28 @@
   [Wootric setCustomFollowupPlaceholderForPromoter:promoterQuestion passive:passiveQuestion detractor:detractorQuestion];
 }
 
+#pragma mark - Custom Values For Eligibility
+
 - (void)setCustomValueForResurveyThrottle:(NSNumber *)resurveyThrottle visitorPercentage:(NSNumber *)visitorPercentage registeredPercentage:(NSNumber *)registeredPercentage dailyResponseCap:(NSNumber *)dailyResponseCap {
   [Wootric setCustomValueForResurveyThrottle:resurveyThrottle visitorPercentage:visitorPercentage registeredPercentage:registeredPercentage dailyResponseCap:dailyResponseCap];
 }
+
+#pragma mark - Color Customization
+
+- (void)setSendButtonBackgroundColor:(UIColor *)color {
+  [Wootric setSendButtonBackgroundColor:color];
+}
+
+- (void)setSliderColor:(UIColor *)color {
+  [Wootric setSliderColor:color];
+}
+
+- (void)setSocialSharingColor:(UIColor *)color {
+  [Wootric setSocialSharingColor:color];
+}
+
+- (void)setThankYouButtonBackgroundColor:(UIColor *)color {
+  [Wootric setThankYouButtonBackgroundColor:color];
+}
+
 @end

--- a/WootricSDK/WootricSDKTests/SEGWootricTests.m
+++ b/WootricSDK/WootricSDKTests/SEGWootricTests.m
@@ -1,0 +1,251 @@
+//
+//  SEGWootricTests.m
+//  WootricSDK
+//
+//  Created by Diego Serrano on 5/31/16.
+//  Copyright © 2016 Wootric. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "WTRApiClient.h"
+#import "SEGWootric.h"
+
+@interface SEGWootricTests : XCTestCase
+
+@property (nonatomic, strong) WTRApiClient *apiClient;
+@property (nonatomic, strong) SEGWootric *segWootric;
+@property (nonatomic, strong) UIColor *color;
+
+@end
+
+@implementation SEGWootricTests
+
+- (void)setUp {
+  [super setUp];
+  _apiClient = [WTRApiClient sharedInstance];
+  _segWootric = [[SEGWootric alloc] init];
+  _color = [UIColor colorWithRed:0.1f green:0.2f blue:0.3f alpha:1.0f];
+}
+
+- (void)tearDown {
+  // Put teardown code here. This method is called after the invocation of each test method in the class.
+  [super tearDown];
+}
+
+- (void)testConfiguration {
+  static NSString *clientId = @"testClientID";
+  static NSString *clientSecret = @"testClientSecret";
+  static NSString *accountToken = @"NP-Token";
+  [_segWootric configureWithClientID:clientId clientSecret:clientSecret accountToken:accountToken];
+  
+  XCTAssertEqualObjects(_apiClient.clientID, clientId, @"clientID should be equal to testClientID");
+  XCTAssertEqualObjects(_apiClient.clientSecret, clientSecret, @"clientSecret should be equal to testClientSecret");
+  XCTAssertEqualObjects(_apiClient.accountToken, accountToken, @"accountToken should be equal to NP-Token");
+  
+  _apiClient.clientID = nil;
+  _apiClient.clientSecret = nil;
+  _apiClient.accountToken = nil;
+}
+
+- (void)testSetEndUserCreatedAt {
+  NSNumber *endUserCreatedAt = @123;
+  [_segWootric setEndUserCreatedAt:endUserCreatedAt];
+  
+  XCTAssertEqualObjects(_apiClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
+  
+  _apiClient.settings.externalCreatedAt = nil;
+}
+
+- (void)testSetEndUserEmail {
+  static NSString *endUserEmail = @"test@example.com";
+  [_segWootric setEndUserEmail:endUserEmail];
+  
+  XCTAssertEqualObjects(_apiClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
+  
+  _apiClient.settings.endUserEmail = nil;
+}
+
+- (void)testSetProductNameForEndUser {
+  static NSString *productName = @"Example";
+  [_segWootric setProductNameForEndUser:@"Example"];
+  
+  XCTAssertEqualObjects(_apiClient.settings.productName, productName, @"productName should be equal to Example");
+  
+  _apiClient.settings.productName = nil;
+}
+
+- (void)testSetCustomLanguage {
+  static NSString *language = @"Epañol";
+  [_segWootric setCustomLanguage:language];
+  
+  XCTAssertEqualObjects(_apiClient.settings.languageCode, language, @"languageCode should be equal to Español");
+  
+  _apiClient.settings.languageCode = nil;
+}
+
+- (void)testSetCustomAudience {
+  static NSString *audience = @"Custom audience";
+  [_segWootric setCustomAudience:audience];
+  
+  XCTAssertEqualObjects(_apiClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
+  
+  _apiClient.settings.customAudience = nil;
+}
+
+- (void)testSetCustomProductName {
+  static NSString *customProductName = @"Custom product";
+  [_segWootric setCustomProductName:customProductName];
+  
+  XCTAssertEqualObjects(_apiClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
+  
+  _apiClient.settings.customProductName = nil;
+}
+
+- (void)testSetCustomFinalThankYou {
+  static NSString *customFinalThankYou = @"CustomFinalThankYou";
+  [_segWootric setCustomFinalThankYou:customFinalThankYou];
+  
+  XCTAssertEqualObjects(_apiClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
+  
+  _apiClient.settings.customFinalThankYou = nil;
+}
+
+- (void)testSetCustomNPSQuestion {
+  static NSString *customNPSQuestion = @"Would you recommend this to a friend?";
+  [_segWootric setCustomNPSQuestion:customNPSQuestion];
+  
+  XCTAssertEqualObjects(_apiClient.settings.customNPSQuestion, customNPSQuestion, @"customNPSQuestion should be equal to Would you recommend this to a friend?");
+  
+  _apiClient.settings.customNPSQuestion = nil;
+}
+
+- (void)testSetEndUserProperties {
+  NSDictionary *endUserProperties = @{@"email": @"test@example.com"};
+  [_segWootric setEndUserProperties:endUserProperties];
+
+  XCTAssertEqualObjects(_apiClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
+  
+  XCTAssertEqualObjects([_apiClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
+  
+  _apiClient.settings.customProperties = nil;
+  
+}
+
+- (void)testSetFirstSurveyAfter {
+  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
+  
+  [_segWootric setFirstSurveyAfter:@15];
+  
+  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
+  
+  _apiClient.settings.firstSurveyAfter = nil;
+  
+}
+
+- (void)testSetSurveyedDefault {
+  XCTAssertTrue(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
+  
+  [_segWootric setSurveyedDefault:NO];
+
+  XCTAssertFalse(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
+  
+  _apiClient.settings.setDefaultAfterSurvey = YES;
+}
+
+- (void)testSurveyImmediately {
+  [_segWootric surveyImmediately:YES];
+  
+  XCTAssertTrue(_apiClient.settings.surveyImmediately, @"surveyImmediately should be true");
+  
+  [_segWootric surveyImmediately:NO];
+  
+  XCTAssertFalse(_apiClient.settings.surveyImmediately, @"surveyImmediately should be false");
+}
+
+- (void)testForceSurvey {
+  [_segWootric forceSurvey:YES];
+  
+  XCTAssertTrue(_apiClient.settings.forceSurvey, @"forceSurvey should be true");
+  
+  _apiClient.settings.forceSurvey = NO;
+}
+
+- (void)testSkipFeedbackScreenForPromoter {
+  [_segWootric skipFeedbackScreenForPromoter:NO];
+  
+  XCTAssertFalse(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
+  
+  [_segWootric skipFeedbackScreenForPromoter:YES];
+  
+  XCTAssertTrue(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
+  
+  _apiClient.settings.skipFeedbackScreen = NO;
+  
+}
+
+- (void)testPassScoreAndTextToURL {
+  [_segWootric passScoreAndTextToURL:NO];
+  
+  XCTAssertFalse(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
+  
+  [_segWootric passScoreAndTextToURL:YES];
+  
+  XCTAssertTrue(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
+  
+  _apiClient.settings.passScoreAndTextToURL = NO;
+}
+
+- (void)testSetFacebookPage {
+  NSURL *url = [NSURL URLWithString:@"facebook.com/test"];
+  [_segWootric setFacebookPage:url];
+  
+  XCTAssertEqualObjects(_apiClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
+  
+  _apiClient.settings.facebookPage = nil;
+}
+
+- (void)testSetTwitterHandler {
+  static NSString *twitterHandler = @"twitter";
+  [_segWootric setTwitterHandler:twitterHandler];
+  
+  XCTAssertEqualObjects(_apiClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
+  
+  _apiClient.settings.twitterHandler = nil;
+  
+}
+
+- (void)testSetSendButtonBackgroundColor {
+  [_segWootric setSendButtonBackgroundColor:_color];
+  
+  XCTAssertEqualObjects(_apiClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
+  
+  _apiClient.settings.sendButtonBackgroundColor = nil;
+}
+
+- (void)testSetSliderColor {
+  [_segWootric setSliderColor:_color];
+  
+  XCTAssertEqualObjects(_apiClient.settings.sliderColor, _color, @"sliderColor should equal to color");
+  
+  _apiClient.settings.sliderColor = nil;
+}
+
+- (void)testSetThankYouButtonBackgroundColor {
+  
+  [_segWootric setThankYouButtonBackgroundColor:_color];
+  
+  XCTAssertEqualObjects(_apiClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
+  
+  _apiClient.settings.thankYouButtonBackgroundColor = nil;
+}
+
+- (void)testSetSocialSharingColor {
+  
+  [_segWootric setSocialSharingColor:_color];
+  
+  XCTAssertEqualObjects(_apiClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
+  
+  _apiClient.settings.socialSharingColor = nil;
+}
+
+@end


### PR DESCRIPTION
Methods added to SEGWootric files to support
color customization. I also added tests for those
files to check that values were indeed
changing.

[Trello card](https://trello.com/c/fPYn8mjB/437-3-add-color-customization-to-segment-integration-ios)

You can test this by creating a new project
and installing the Wootric Segment pod.
`pod "Segment-Wootric"`

This pod will use the WootricSDK from 
`master`. So for the project to use 
this PR branch, the **Podfile** should
look like this:

```
target 'ProjectName' do
  pod "Segment-Wootric"
  pod "WootricSDK", :git => 'https://github.com/Wootric/WootricSDK-iOS.git', :branch => 'ds-segment-color-customization'
end
```

Instructions on the Segment Wootric
integration are here
[Github Segment Wootric](https://github.com/Wootric/segment-wootric-ios)

**Example**

``` objective-c
SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"SEGMENT_WRITE_KEY"];
  WTRWootricIntegrationFactory *wootricFactory = [WTRWootricIntegrationFactory instance];
  [config use:wootricFactory];
  [SEGAnalytics setupWithConfiguration:config];
  [[WTRWootricIntegration wootric] configureWithClientID:@"CLIENT_ID"
                                            clientSecret:@"CLIENT_SECRET"
                                            accountToken:@"NPS_TOKEN"];
  [[WTRWootricIntegration wootric] forceSurvey:YES];
  [[WTRWootricIntegration wootric] setSliderColor:[UIColor colorWithRed:1/255.0f green:100/255.0f blue:120/255.0f alpha:1.0f]];
  [[WTRWootricIntegration wootric] setSendButtonBackgroundColor:[UIColor colorWithRed:200/255.0f green:100/255.0f blue:10/255.0f alpha:1.0f]];
  [[WTRWootricIntegration wootric] setThankYouButtonBackgroundColor:[UIColor colorWithRed:100/255.0f green:10/255.0f blue:120/255.0f alpha:1.0f]];
  [[WTRWootricIntegration wootric] setSocialSharingColor:[UIColor colorWithRed:100/255.0f green:100/255.0f blue:10/255.0f alpha:1.0f]];
  [WTRWootricIntegration showSurveyInViewController:self];
```
