### PR TITLE
Eliminate memory leaks

### DIFF
--- a/WootricSDK/WootricSDK/UIItems.m
+++ b/WootricSDK/WootricSDK/UIItems.m
@@ -31,19 +31,19 @@
 
 + (void)dynamicallyAddFont {
   NSString *fontPath = [[NSBundle bundleForClass:[UIItems class]] pathForResource:@"fontawesome-webfont" ofType:@"ttf"];
-  NSData *fontData = [NSData dataWithContentsOfFile:fontPath];
-    
+  
   CFErrorRef error;
-  CGDataProviderRef provider = CGDataProviderCreateWithCFData((CFDataRef) fontData);
-  CGFontRef font = CGFontCreateWithDataProvider(provider);
-  if (!CTFontManagerRegisterGraphicsFont(font, &error)) {
-    if (CFErrorGetCode(error) == kCTFontManagerErrorAlreadyRegistered) { return; }
-      CFStringRef errorDescription = CFErrorCopyDescription(error);
-      NSLog(@"WootricSDK: Failed to load font: %@", errorDescription);
-      CFRelease(errorDescription);
+  NSURL *url = [NSURL fileURLWithPath:fontPath isDirectory:NO];
+  if (!CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error)) {
+    if (CFErrorGetCode(error) == kCTFontManagerErrorAlreadyRegistered) {
+      CFRelease(error);
+      return;
+    }
+    CFStringRef errorDescription = CFErrorCopyDescription(error);
+    NSLog(@"WootricSDK: Failed to load font: %@", errorDescription);
+    CFRelease(errorDescription);
+    CFRelease(error);
   }
-  CFRelease(font);
-  CFRelease(provider);
 }
 
 + (UILabel *)likelyAnchorWithSettings:(WTRSettings *)settings andFont:(UIFont *)font {


### PR DESCRIPTION
https://trello.com/c/oUYSufYN/485-2-5-get-data-for-sdk-overhead-on-cpu-memory-battery-network-data-consumption

While getting the data for SDK overhead I
discovered some memory leaks that I decided
to fix. While importing Awesome Font (which
is used for social media icons) there were
some objects references that were not being
released correctly.

I case you want to check this for yourself
you'll need to use Instruments, Xcode's tool
for analysis.

To use Instruments you can select
Product->Profile (or hit command+I). This will
profile the app with the selected device and
launch Instruments. There, you can pick the
Leaks profiling template. Now, profiling on
Xcode will launch the app on the selected device
and show leaks and memory allocation on Instruments.
