### PR TITLE
Response/decline throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.7 (2016-08-31)
+
+### Changed:
+
+- Accept resurvey_throttle and decline_resurvey_throttle
+- Fix last button long text adjustment
+- Update tests
+- Add tests for WTRDefaults
+
 ## 0.5.6 (2016-06-29)
 
 ### Added:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.5.6'
+  s.version  = '0.5.7'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
 		0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */; };
+		0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */; };
 		7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */; };
 		7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */; };
 		7E74E3391C8E99C300BCB84F /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7E74E3381C8E99C300BCB84F /* fontawesome-webfont.ttf */; };
@@ -111,6 +112,7 @@
 /* Begin PBXFileReference section */
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
 		0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRApiClientTests.m; sourceTree = "<group>"; };
+		0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRDefaultsTests.m; sourceTree = "<group>"; };
 		7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FontAwesome.h"; sourceTree = "<group>"; };
 		7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FontAwesome.m"; sourceTree = "<group>"; };
 		7E74E3381C8E99C300BCB84F /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 			isa = PBXGroup;
 			children = (
 				B21372951BED0DB1009F5974 /* WTRSurveyTests.m */,
+				0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */,
 				B29D63C91BC3CEEB00F0C98C /* WTRSettingsTests.m */,
 				B2DC6F121B81E6F900F599B3 /* Supporting Files */,
 				0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */,
@@ -638,6 +641,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B29D63CA1BC3CEEB00F0C98C /* WTRSettingsTests.m in Sources */,
+				0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */,
 				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
 				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.6</string>
+	<string>0.5.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -269,6 +269,7 @@
         if ([responseJSON[@"eligible"] isEqual:@1] || _settings.forceSurvey) {
           if (_settings.forceSurvey) NSLog(@"WootricSDK: forced survey (remove for production!)");
           NSLog(@"WootricSDK: User eligible");
+
           [_settings parseDataFromSurveyServer:responseJSON];
           _userID = responseJSON[@"settings"][@"user_id"];
           

--- a/WootricSDK/WootricSDK/WTRDefaults.h
+++ b/WootricSDK/WootricSDK/WTRDefaults.h
@@ -27,7 +27,7 @@
 @interface WTRDefaults : NSObject
 
 + (void)setLastSeenAt;
-+ (void)setSurveyed;
++ (void)setSurveyedWithType:(NSString *)type;
 + (void)checkIfSurveyedDefaultExpired;
 
 @end

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -39,12 +39,14 @@
 @property (nonatomic, strong) NSNumber *registeredPercentage;
 @property (nonatomic, strong) NSNumber *visitorPercentage;
 @property (nonatomic, strong) NSNumber *resurveyThrottle;
+@property (nonatomic, strong) NSNumber *declineResurveyThrottle;
 @property (nonatomic, strong) NSNumber *dailyResponseCap;
 @property (nonatomic, strong) NSNumber *externalCreatedAt;
 @property (nonatomic, strong) NSNumber *firstSurveyAfter;
 @property (nonatomic, strong) NSURL *facebookPage;
 @property (nonatomic, strong) NSDictionary *customProperties;
 @property (nonatomic, assign) NSInteger surveyedDefaultDuration;
+@property (nonatomic, assign) NSInteger surveyedDefaultDurationDecline;
 @property (nonatomic, assign) NSInteger timeDelay;
 @property (nonatomic, assign) BOOL surveyImmediately;
 @property (nonatomic, assign) BOOL forceSurvey;

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -45,6 +45,7 @@
   if (self = [super init]) {
     _setDefaultAfterSurvey = YES;
     _surveyedDefaultDuration = 90;
+    _surveyedDefaultDurationDecline = 30;
     _firstSurveyAfter = @0;
     _originURL = [[NSBundle mainBundle] bundleIdentifier];
     _customThankYou = [[WTRCustomThankYou alloc] init];
@@ -63,6 +64,8 @@
     localizedTextsFromSurvey = surveyServerSettings[@"settings"][@"localized_texts"];
     customMessagesFromSurvey = surveyServerSettings[@"settings"][@"messages"];
     NSNumber *firstSurvey = surveyServerSettings[@"settings"][@"first_survey"];
+    NSNumber *resurveyThrottleFromServer = surveyServerSettings[@"settings"][@"resurvey_throttle"];
+    NSNumber *declineResurveyThrottleFromServer = surveyServerSettings[@"settings"][@"decline_resurvey_throttle"];
     NSInteger delay = [surveyServerSettings[@"settings"][@"time_delay"] integerValue];
         
     if (localizedTextsFromSurvey) {
@@ -79,6 +82,14 @@
         
     if (delay > 0) {
       _timeDelay = delay;
+    }
+    
+    if (resurveyThrottleFromServer) {
+      _surveyedDefaultDuration = [resurveyThrottleFromServer intValue];
+    }
+    
+    if (declineResurveyThrottleFromServer) {
+      _surveyedDefaultDurationDecline = [declineResurveyThrottleFromServer intValue];
     }
   }
 }

--- a/WootricSDK/WootricSDK/WTRSurvey.m
+++ b/WootricSDK/WootricSDK/WTRSurvey.m
@@ -43,12 +43,12 @@
 
 - (void)endUserDeclined {
   [[WTRApiClient sharedInstance] endUserDeclined];
-  [WTRDefaults setSurveyed];
+  [WTRDefaults setSurveyedWithType:@"decline"];
 }
 
 - (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text {
   [[WTRApiClient sharedInstance] endUserVotedWithScore:score andText:text];
-  [WTRDefaults setSurveyed];
+  [WTRDefaults setSurveyedWithType:@"response"];
 }
 
 - (void)survey:(void (^)())showSurvey {
@@ -68,7 +68,15 @@
 - (BOOL)needsSurvey {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   if ([defaults boolForKey:@"surveyed"]) {
-    NSLog(@"WootricSDK: needsSurvey(NO) - Already surveyed in last %d days", (int)_apiClient.settings.surveyedDefaultDuration);
+    NSInteger days;
+    if ([defaults objectForKey:@"resurvey_days"]) {
+      days = [defaults integerForKey:@"resurvey_days"];
+    } else if([[defaults objectForKey:@"type"] isEqualToString:@"response"]){
+      days = _apiClient.settings.surveyedDefaultDuration;
+    } else {
+      days = _apiClient.settings.surveyedDefaultDurationDecline;
+    }
+    NSLog(@"WootricSDK: needsSurvey(NO) - Already surveyed in last %li days", (long)days);
     return NO;
   } else if (_apiClient.settings.surveyImmediately) {
     NSLog(@"WootricSDK: needsSurvey(YES) - surveyImmediately");

--- a/WootricSDK/WootricSDK/WTRThankYouButton.m
+++ b/WootricSDK/WootricSDK/WTRThankYouButton.m
@@ -34,6 +34,7 @@
     self.backgroundColor = backgroundColor;
     self.layer.borderColor = [backgroundColor colorWithAlphaComponent:0.65f].CGColor;
     self.titleLabel.font = [UIFont boldSystemFontOfSize:14];
+    self.titleLabel.adjustsFontSizeToFitWidth = YES;
     [self setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     [self setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self addTarget:viewController action:NSSelectorFromString(@"openThankYouURL:") forControlEvents:UIControlEventTouchUpInside];

--- a/WootricSDK/WootricSDKTests/WTRDefaultsTests.m
+++ b/WootricSDK/WootricSDKTests/WTRDefaultsTests.m
@@ -1,0 +1,182 @@
+//
+//  WTRDefaultsTests.m
+//  WootricSDK
+//
+//  Created by Diego Serrano on 8/18/16.
+//  Copyright © 2016 Wootric. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "WTRDefaults.h"
+#import "WTRApiClient.h"
+
+@interface WTRDefaultsTests : XCTestCase
+
+@property (nonatomic, strong) WTRApiClient *apiClient;
+@property (nonatomic, strong) NSUserDefaults *defaults;
+
+@end
+
+@implementation WTRDefaultsTests
+
+- (void)setUp {
+  [super setUp];
+  _apiClient = [WTRApiClient sharedInstance];
+  _defaults = [NSUserDefaults standardUserDefaults];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  
+  [_defaults setObject:nil forKey:@"type"];
+  [_defaults setObject:nil forKey:@"surveyed"];
+  [_defaults setObject:nil forKey:@"lastSeenAt"];
+  [_defaults setObject:nil forKey:@"surveyedAt"];
+  _apiClient.settings.surveyedDefaultDurationDecline = 30;
+  _apiClient.settings.surveyedDefaultDuration = 90;
+}
+
+- (void)testSetLastSeenAtNotSet {
+  [_defaults setDouble:0.0f forKey:@"lastSeenAt"];
+  [WTRDefaults setLastSeenAt];
+  XCTAssertNotEqual(0.0f, [[_defaults objectForKey:@"lastSeenAt"] doubleValue]);
+}
+
+- (void)testSetLastSeenAtGreaterThanTimestamp {
+  double oldDate = [[self createdDaysAgo:91] doubleValue];
+  [_defaults setDouble:oldDate forKey:@"lastSeenAt"];
+  [WTRDefaults setLastSeenAt];
+  XCTAssertNotEqual(oldDate, [[_defaults objectForKey:@"lastSeenAt"] doubleValue]);
+}
+
+- (void)testSetLastSeenAtLessThanTimestamp {
+  double oldDate = [[self createdDaysAgo:89] doubleValue];
+  [_defaults setDouble:oldDate forKey:@"lastSeenAt"];
+  [WTRDefaults setLastSeenAt];
+  XCTAssertEqual(oldDate, [[_defaults objectForKey:@"lastSeenAt"] doubleValue]);
+}
+
+- (void)testCheckIfSurveyedDefaultExpiredResponseNotSet {
+  [_defaults setBool:YES forKey:@"surveyed"];
+  [_defaults setObject:@"" forKey:@"type"];
+  
+  [_defaults setDouble:[[self createdDaysAgo:1] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:35] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:91] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testCheckIfSurveyedDefaultExpiredIsResponse {
+  [_defaults setObject:@"response" forKey:@"type"];
+  [_defaults setBool:YES forKey:@"surveyed"];
+  
+  [_defaults setDouble:[[self createdDaysAgo:1] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:31] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:91] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testCheckIfSurveyedDefaultExpiredIsDecline {
+  [_defaults setObject:@"decline" forKey:@"type"];
+  [_defaults setBool:YES forKey:@"surveyed"];
+  
+  [_defaults setDouble:[[self createdDaysAgo:1] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:31] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testCheckIfSurveyedDefaultExpiredIsResponseAndCustomDuration {
+  [_defaults setObject:@"response" forKey:@"type"];
+  [_defaults setBool:YES forKey:@"surveyed"];
+  _apiClient.settings.surveyedDefaultDuration = 10;
+  
+  [_defaults setDouble:[[self createdDaysAgo:1] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:11] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testCheckIfSurveyedDefaultExpiredIsDeclineAndCustomDuration {
+  [_defaults setObject:@"decline" forKey:@"type"];
+  [_defaults setBool:YES forKey:@"surveyed"];
+  _apiClient.settings.surveyedDefaultDurationDecline = 20;
+  
+  [_defaults setDouble:[[self createdDaysAgo:1] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+  
+  [_defaults setDouble:[[self createdDaysAgo:21] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testSetSurveyedWithTypeResponseAndAfterSurveyYES {
+  [_defaults setObject:nil forKey:@"type"];
+  [_defaults setBool:NO forKey:@"surveyed"];
+  _apiClient.settings.setDefaultAfterSurvey = YES;
+  
+  [WTRDefaults setSurveyedWithType:@"response"];
+  
+  XCTAssertEqual([_defaults objectForKey:@"type"], @"response");
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testSetSurveyedWithTypeResponseAndAfterSurveyNO {
+  [_defaults setObject:nil forKey:@"type"];
+  [_defaults setBool:NO forKey:@"surveyed"];
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  
+  [WTRDefaults setSurveyedWithType:@"response"];
+  
+  XCTAssertNotEqual([_defaults objectForKey:@"type"], @"response");
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testSetSurveyedWithTypeDeclineAndAfterSurveyYES {
+  [_defaults setObject:nil forKey:@"type"];
+  [_defaults setBool:NO forKey:@"surveyed"];
+  _apiClient.settings.setDefaultAfterSurvey = YES;
+  
+  [WTRDefaults setSurveyedWithType:@"decline"];
+  
+  XCTAssertEqual([_defaults objectForKey:@"type"], @"decline");
+  XCTAssertTrue([_defaults boolForKey:@"surveyed"]);
+}
+
+- (void)testSetSurveyedWithTypeDeclineAndAfterSurveyNO {
+  [_defaults setObject:nil forKey:@"type"];
+  [_defaults setBool:NO forKey:@"surveyed"];
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  
+  [WTRDefaults setSurveyedWithType:@"decline"];
+  
+  XCTAssertNotEqual([_defaults objectForKey:@"type"], @"decline");
+  XCTAssertFalse([_defaults boolForKey:@"surveyed"]);
+}
+
+- (NSNumber *)createdDaysAgo:(int)daysAgo {
+  return [NSNumber numberWithDouble:[[NSDate date] timeIntervalSince1970] - (daysAgo * 60 * 60 * 24)];
+}
+
+@end

--- a/WootricSDK/WootricSDKTests/WTRSurveyTests.m
+++ b/WootricSDK/WootricSDKTests/WTRSurveyTests.m
@@ -40,6 +40,7 @@
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setBool:NO forKey:@"surveyed"];
   [defaults setDouble:0 forKey:@"lastSeenAt"];
+  [defaults setObject:nil forKey:@"resurvey_days"];
 }
 
 // surveyImmediately = YES
@@ -77,17 +78,57 @@
   XCTAssertFalse([_surveyClient needsSurvey]);
 }
 
-// surveyed > 90 days
+// surveyed > 90 days, surveyed = YES
 - (void)testNeedsSurveySix {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setBool:YES forKey:@"surveyed"];
-  [defaults setDouble:[[self createdDaysAgo:91] doubleValue] forKey:@"surveyedAt"];
+  [defaults setDouble:[[self createdDaysAgo:95] doubleValue] forKey:@"surveyedAt"];
   [WTRDefaults checkIfSurveyedDefaultExpired];
   XCTAssertTrue([_surveyClient needsSurvey]);
 }
 
-// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 60, externalCreatedAt = 20, lastSeenAt = 40
+// surveyed > 90 days, surveyed = YES, type = response
 - (void)testNeedsSurveySeven {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"response" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:95] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed < 90 days, surveyed = YES, type = response
+- (void)testNeedsSurveyEight {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"response" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:85] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_surveyClient needsSurvey]);
+}
+
+// surveyed > 30 days, surveyed = YES, type = decline
+- (void)testNeedsSurveyNine {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"decline" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:35] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed < 30 days, surveyed = YES, type = decline
+- (void)testNeedsSurveyTen {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"decline" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:25] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_surveyClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 60, externalCreatedAt = 20, lastSeenAt = 40
+- (void)testNeedsSurveyEleven {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setDouble:[[self createdDaysAgo:40] doubleValue] forKey:@"lastSeenAt"];
   _apiClient.settings.firstSurveyAfter = @60;
@@ -96,11 +137,20 @@
 }
 
 // surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 31, externalCreatedAt = 20, lastSeenAt = 40
-- (void)testNeedsSurveyEight {
+- (void)testNeedsSurveyTwelve {
   _apiClient.settings.firstSurveyAfter = @31;
   _apiClient.settings.externalCreatedAt = [self createdDaysAgo:20];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setDouble:[[self createdDaysAgo:40] doubleValue] forKey:@"lastSeenAt"];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 2, externalCreatedAt = 2, lastSeenAt = 4
+- (void)testNeedsSurveyThirteen {
+  _apiClient.settings.firstSurveyAfter = @2;
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:2];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setDouble:[[self createdDaysAgo:4] doubleValue] forKey:@"lastSeenAt"];
   XCTAssertTrue([_surveyClient needsSurvey]);
 }
 


### PR DESCRIPTION
Updates the SDK to accept resurvey_throttle and decline_resurvey_throttle.
In case the end_user responds to the survey, the value of resurvey_throttle
will be used to set the expiration date of the surveyedAt value of
NSUserDefaults (cookie), resurvey_throttle default value is 90.
In case the end_user declines the survey, the value of decline_resurvey_throttle
will be used as the expiration date, default value is 30.

Other fixes:
-Fix last button long text adjustment
-Update tests
-Add tests for WTRDefaults

To test this manually, you can complete a survey, then run the app again, it should log a message that the "user was already surveyed in the last 90 days" (90 being the default value for responses). 

To erase the "cookies", delete the app from the device/simulator, install the app again. 

Now try declining the survey. When running the app again it should say "user was already surveyed in the last 30 days" (30 being the default value for declines).

Trello: https://trello.com/c/hAeqz6Zr/733-1-custom-throttle-for-decline-response-ios-update-the-clients-need-the-new-response-resurvey-date-and-decline-resurvey-date-in-o
