### PR TITLE
Allow iOS SDK to pass external_id and phone_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.8 (2016-09-07)
+
+### Added:
+
+- Pass external_id & phone_number
+- Update tests
+
 ## 0.5.7 (2016-08-31)
 
 ### Changed:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.5.6"
+	pod "WootricSDK", "~> 0.5.8"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,9 +1,10 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.5.7'
+  s.version  = '0.5.8'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'
+  s.documentation_url = 'http://docs.wootric.com/ios/'
   s.social_media_url = 'https://twitter.com/Wootric'
   s.authors  = { 'Wootric' => 'support@wootric.com' }
   s.source   = { :git => 'https://github.com/Wootric/WootricSDK-iOS.git', :tag => s.version.to_s }

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.7</string>
+	<string>0.5.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -377,6 +377,16 @@
                      baseURLString, [_settings.firstSurveyAfter intValue]];
   }
   
+  if (_settings.externalId) {
+    baseURLString = [NSString stringWithFormat:@"%@&external_id=%@",
+                     baseURLString, _settings.externalId];
+  }
+  
+  if (_settings.phoneNumber) {
+    baseURLString = [NSString stringWithFormat:@"%@&phone_number=%@",
+                     baseURLString, _settings.phoneNumber];
+  }
+  
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   double lastSeen = [defaults doubleForKey:@"lastSeenAt"];
   baseURLString = [NSString stringWithFormat:@"%@&end_user_last_seen=%.0f", baseURLString, lastSeen];

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -36,6 +36,8 @@
 @property (nonatomic, strong) NSString *customAudience;
 @property (nonatomic, strong) NSString *customFinalThankYou;
 @property (nonatomic, strong) NSString *customNPSQuestion;
+@property (nonatomic, strong) NSString *externalId;
+@property (nonatomic, strong) NSString *phoneNumber;
 @property (nonatomic, strong) NSNumber *registeredPercentage;
 @property (nonatomic, strong) NSNumber *visitorPercentage;
 @property (nonatomic, strong) NSNumber *resurveyThrottle;

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -50,6 +50,16 @@
 */
 + (void)setEndUserEmail:(NSString *)endUserEmail;
 /**
+ @discussion It sets an end user's external id.
+ @param externalId NSString of the end user's external id.
+ */
++ (void)setEndUserExternalId:(NSString *)externalId;
+/**
+ @discussion It sets end user's phone number.
+ @param phoneNumber NSString of the end user's phone number.
+ */
++ (void)setEndUserPhoneNumber:(NSString *)phoneNumber;
+/**
  @discussion Adds a product name to end user's properties.
  @param productName NSString of the end user's product name.
 */

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -50,6 +50,16 @@
   apiClient.settings.externalCreatedAt = externalCreatedAt;
 }
 
++ (void)setEndUserExternalId:(NSString *)externalId {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.settings.externalId = externalId;
+}
+
++ (void)setEndUserPhoneNumber:(NSString *)phoneNumber {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.settings.phoneNumber = phoneNumber;
+}
+
 + (void)setCustomAudience:(NSString *)audience {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.customAudience = audience;

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -158,6 +158,12 @@
   
   _apiClient.settings.firstSurveyAfter = @1;
   XCTAssertEqualObjects([_apiClient addSurveyServerCustomSettingsToURLString:baseURLString], @"https://survey.wootric.com/eligible.json?account_token=NPS-token&email=a@test.com&survey_immediately=1&registered_percent=50&visitor_percent=50&resurvey_throttle=100&daily_response_cap=25&end_user_created_at=1234567890&language[code]=ES&language[product_name]=productName&language[audience_text]=customAudience&first_survey_delay=1&end_user_last_seen=0");
+  
+  _apiClient.settings.externalId = @"a1b2c3d4";
+  XCTAssertEqualObjects([_apiClient addSurveyServerCustomSettingsToURLString:baseURLString], @"https://survey.wootric.com/eligible.json?account_token=NPS-token&email=a@test.com&survey_immediately=1&registered_percent=50&visitor_percent=50&resurvey_throttle=100&daily_response_cap=25&end_user_created_at=1234567890&language[code]=ES&language[product_name]=productName&language[audience_text]=customAudience&first_survey_delay=1&external_id=a1b2c3d4&end_user_last_seen=0");
+  
+  _apiClient.settings.phoneNumber = @"+0123456789";
+  XCTAssertEqualObjects([_apiClient addSurveyServerCustomSettingsToURLString:baseURLString], @"https://survey.wootric.com/eligible.json?account_token=NPS-token&email=a@test.com&survey_immediately=1&registered_percent=50&visitor_percent=50&resurvey_throttle=100&daily_response_cap=25&end_user_created_at=1234567890&language[code]=ES&language[product_name]=productName&language[audience_text]=customAudience&first_survey_delay=1&external_id=a1b2c3d4&phone_number=+0123456789&end_user_last_seen=0");
 }
 
 - (void)testRequestURL {


### PR DESCRIPTION
-Update version 0.5.8
-Update tests
-Update podspec with iOS docs url

Trello: https://trello.com/c/XPfvAcRX/777-allow-ios-sdk-to-pass-user-id-and-phone
