### PR TITLE
Bundle Info.plist causing archive errors

### DIFF
--- a/WootricSDK/WootricSDK/WootricSDK.bundle/Info.plist
+++ b/WootricSDK/WootricSDK/WootricSDK.bundle/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -13,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.5.9</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
Using Wootric in combination with Cocoapods and the `use_frameworks!` option, archiving builds and submitting them to iTC generate validation errors preventing submission. The error returned was as follows:

```
Info.plist of ../Frameworks/WootricSDK.framework/WootricSDK.bundle specifies a non-existent file for the CFBundleExecutable key
```

This PR corrects this issue by removing the `CFBundleExecutable` key and changing the `CFBundlePackageType` to `BNDL`. This has allowed for builds to be archived and submitted without issue.

This was experienced on Xcode 8.0 and Cocoapods 1.10.rc2 in a Swift 2.3 project. It was replicated on both local dev machines and CI servers.
