### PR TITLE
Remove product_name as an end_user_property update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.5 (2017-12-14)
+
+### Fixed:
+
+- Fix end user updater method
+
 ## 0.6.4 (2017-11-24)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.6.4"
+	pod "WootricSDK", "~> 0.6.5"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.6.4'
+  s.version  = '0.6.5'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.4</string>
+	<string>0.6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -131,11 +131,6 @@
   BOOL needsUpdate = NO;
   NSString *escapedEmail = [self percentEscapeString:[_settings getEndUserEmailOrUnknown]];
   NSString *params = [NSString stringWithFormat:@"email=%@", escapedEmail];
-
-  if (_settings.productName) {
-    needsUpdate = YES;
-    params = [NSString stringWithFormat:@"%@&properties[product_name]=%@", params, _settings.productName];
-  }
   
   if (_settings.externalId) {
     needsUpdate = YES;


### PR DESCRIPTION
Looks like this code was added from the initial commit. I don't know if
this was intended or by mistake, but we're updating end user's properties
with  a product_name property whenever the product_name is present.