### PR TITLE
Escape product_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.5 (2017-12-14)
+
+### Fixed:
+
+- Fix char escaping when updating end user with product_name
+
 ## 0.6.4 (2017-11-24)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.6.4"
+	pod "WootricSDK", "~> 0.6.5"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.6.4'
+  s.version  = '0.6.5'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.4</string>
+	<string>0.6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -134,7 +134,7 @@
 
   if (_settings.productName) {
     needsUpdate = YES;
-    params = [NSString stringWithFormat:@"%@&properties[product_name]=%@", params, _settings.productName];
+    params = [NSString stringWithFormat:@"%@&properties[product_name]=%@", params, [self percentEscapeString:_settings.productName]];
   }
   
   if (_settings.externalId) {

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -187,7 +187,6 @@
   urlRequest = [_apiClient requestWithURL:url HTTPMethod:nil andHTTPBody:params];
   httpBody = [[NSString alloc] initWithData:urlRequest.HTTPBody encoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(httpBody, @"params&os_name=iOS&sdk_version=0.6.0&os_version=10.0");
-  
 }
 
 - (void)testAddVersionsToURLString {


### PR DESCRIPTION
Escape product_name when updating end user

## How to test
- Use `[Wootric setProductNameForEndUser:<PRODUCT_NAME>];` to set the product name. Use something with spaces to check that they're escaped correctly. 