### PR TITLE
Fix user defaults check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.6 (2017-12-15)
+
+### Fixed:
+
+- Check for setDefaultAfterSurvey when checking defaults values
+
 ## 0.6.5 (2017-12-14)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.6.5"
+	pod "WootricSDK", "~> 0.6.6"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.6.5'
+  s.version  = '0.6.6'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.5</string>
+	<string>0.6.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRDefaults.m
+++ b/WootricSDK/WootricSDK/WTRDefaults.m
@@ -31,6 +31,7 @@
 
 + (void)setLastSeenAt {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
   if ([defaults doubleForKey:@"lastSeenAt"] == 0) {
     [defaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:@"lastSeenAt"];
   } else {
@@ -43,25 +44,27 @@
 
 + (void)setSurveyedWithType:(NSString *)type {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  
   if (apiClient.settings.setDefaultAfterSurvey) {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-
     [defaults setBool:YES forKey:@"surveyed"];
     [defaults setObject:type forKey:@"type"];
     if([type isEqualToString:@"decline"]){
-      [defaults setInteger:apiClient.settings.surveyedDefaultDurationDecline forKey:@"resurvey_days"];;
+      [defaults setInteger:apiClient.settings.surveyedDefaultDurationDecline forKey:@"resurvey_days"];
     } else {
       [defaults setInteger:apiClient.settings.surveyedDefaultDuration forKey:@"resurvey_days"];
     }
     [defaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:@"surveyedAt"];
+  } else {
+    [defaults setBool:NO forKey:@"surveyed"];
+    [defaults setObject:nil forKey:@"type"];
   }
 }
 
 + (void)checkIfSurveyedDefaultExpired {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  
+
   double surveyedDurationTimestamp = apiClient.settings.surveyedDefaultDuration;
   if ([defaults objectForKey:@"resurvey_days"] && [defaults integerForKey:@"resurvey_days"] >= 0) {
     surveyedDurationTimestamp = [defaults integerForKey:@"resurvey_days"];

--- a/WootricSDK/WootricSDK/WTRSurvey.m
+++ b/WootricSDK/WootricSDK/WTRSurvey.m
@@ -67,7 +67,7 @@
 
 - (BOOL)needsSurvey {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  if ([defaults boolForKey:@"surveyed"]) {
+  if ([defaults boolForKey:@"surveyed"] && _apiClient.settings.setDefaultAfterSurvey) {
     NSInteger days;
     if ([defaults objectForKey:@"resurvey_days"]) {
       days = [defaults integerForKey:@"resurvey_days"];

--- a/WootricSDK/WootricSDKTests/WTRSurveyTests.m
+++ b/WootricSDK/WootricSDKTests/WTRSurveyTests.m
@@ -30,6 +30,7 @@
   [super setUp];
   _apiClient = [WTRApiClient sharedInstance];
   _surveyClient = [[WTRSurvey alloc] init];
+  _apiClient.settings.setDefaultAfterSurvey = YES;
 }
 
 - (void)tearDown {
@@ -150,6 +151,41 @@
   _apiClient.settings.firstSurveyAfter = @2;
   _apiClient.settings.externalCreatedAt = [self createdDaysAgo:2];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setDouble:[[self createdDaysAgo:4] doubleValue] forKey:@"lastSeenAt"];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed = YES, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = YES
+- (void)testNeedsSurveyFourteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  XCTAssertFalse([_surveyClient needsSurvey]);
+}
+
+// surveyed = YES, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = NO
+- (void)testNeedsSurveyFifteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = YES
+- (void)testNeedsSurveySixteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:NO forKey:@"surveyed"];
+  XCTAssertTrue([_surveyClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = NO
+- (void)testNeedsSurveySeventeen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:NO forKey:@"surveyed"];
   [defaults setDouble:[[self createdDaysAgo:4] doubleValue] forKey:@"lastSeenAt"];
   XCTAssertTrue([_surveyClient needsSurvey]);
 }


### PR DESCRIPTION
Make the SDK check for the value of `_apiClient.settings.setDefaultAfterSurvey` when checking for `NSUserDefaults` values.

If `setDefaultAfterSurvey` it means the customer doesn't want for the cookie to be checked, so we shouldn't consider the value of `[defaults boolForKey:@"surveyed"]` and hit eligibility server.