### PR TITLE
Better keyboard handling

### DIFF
--- a/WootricSDK/WootricSDK/WTRFeedbackView.h
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.h
@@ -38,4 +38,11 @@
 - (BOOL)feedbackTextPresent;
 - (BOOL)isActive;
 
+/**
+ *  If this view has an active first responder (e.g. the feedback text field), this provides the rect within
+ *   the WTRFeedbackView bounds for that view.
+ *  Returns CGRectNull if there is no first responder within this view.
+ */
+- (CGRect)frameForFirstResponder;
+
 @end

--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -96,6 +96,15 @@
   return !self.hidden;
 }
 
+- (CGRect)frameForFirstResponder
+{
+  if (_feedbackTextView.isFirstResponder) {
+    return _feedbackTextView.frame;
+  }
+  
+  return CGRectZero;
+}
+
 - (void)setupEditScoreButtonWithViewController:(UIViewController *)viewController {
   _editScoreButton = [[UIButton alloc] init];
   _editScoreButton.titleLabel.font = [UIFont boldSystemFontOfSize:12];

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -339,21 +339,24 @@
 
 - (void)registerForKeyboardNotification {
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillShow:")
-                                               name:UIKeyboardWillShowNotification
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillHide:")
-                                               name:UIKeyboardWillHideNotification
-                                             object:nil];
+                                            selector:@selector(keyboardFrameChanging:)
+                                                name:UIKeyboardWillChangeFrameNotification
+                                              object:nil];
 }
 
-- (void)keyboardWillShow:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:YES notification:notification];
-}
-
-- (void)keyboardWillHide:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:NO notification:notification];
+- (void)keyboardFrameChanging:(NSNotification *)notification {
+  CGRect keyboardFrameInWindow = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  CGRect scrollViewFrameInWindow = [_scrollView convertRect:_scrollView.bounds toView:nil];
+  CGRect overlap = CGRectIntersection(keyboardFrameInWindow, scrollViewFrameInWindow);
+  NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] floatValue];
+  UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
+  CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
+  
+  [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
+    self->_scrollView.contentInset = insets;
+    self->_scrollView.scrollIndicatorInsets = insets;
+    self->_scrollView.contentOffset = contentOffset;
+  } completion:nil];
 }
 
 - (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -34,7 +34,6 @@
 
 @interface WTRSurveyViewController ()
 
-@property (nonatomic, assign) BOOL scrolled;
 @property (nonatomic, assign) BOOL alreadyVoted;
 @property (nonatomic, assign) CGFloat keyboardHeight;
 @property (nonatomic, strong) CAGradientLayer *gradient;
@@ -92,7 +91,6 @@
 
 - (void)editScoreButtonPressed:(UIButton *)sender {
   [_feedbackView textViewResignFirstResponder];
-  _scrolled = NO;
   [self setQuestionViewVisible:YES andFeedbackViewVisible:NO];
 }
 
@@ -328,7 +326,6 @@
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
   [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-  _scrolled = NO;
 
   BOOL isFromLandscape = UIInterfaceOrientationIsLandscape(fromInterfaceOrientation);
   CGRect bounds = self.view.bounds;
@@ -357,23 +354,6 @@
     self->_scrollView.scrollIndicatorInsets = insets;
     self->_scrollView.contentOffset = contentOffset;
   } completion:nil];
-}
-
-- (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {
-  NSDictionary *userInfo = notification.userInfo ? notification.userInfo : @{};
-  CGRect keyboardFrame = [userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  double adjustmentHeight = CGRectGetHeight(keyboardFrame) * (show ? 1 : -1);
-  UIEdgeInsets contentInsets = UIEdgeInsetsMake(0, 0, adjustmentHeight, 0);
-  _scrollView.contentInset = contentInsets;
-  _scrollView.scrollIndicatorInsets = contentInsets;
-
-  if ((_keyboardHeight != keyboardFrame.size.height)) {
-    _keyboardHeight = keyboardFrame.size.height;
-    [_scrollView setContentOffset:CGPointMake(0, _keyboardHeight) animated:YES];
-  } else if (!_scrolled) {
-    [_scrollView scrollRectToVisible:_modalView.frame animated:YES];
-    _scrolled = YES;
-  }
 }
 
 - (void)textViewDidChange:(UITextView *)textView {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -349,6 +349,20 @@
   UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
   CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
   
+  // If the text view is off screen, fix that
+  if ([_feedbackView isActive]) {
+    CGRect firstResponderFrame = [_feedbackView frameForFirstResponder];
+    
+    if (!CGRectIsEmpty(firstResponderFrame)) {
+      // We have a first responder within the feedback view.  Is it off screen?
+      CGRect firstResponderFrameInScrollView = [_scrollView convertRect:firstResponderFrame fromView:_feedbackView];
+      
+      if (contentOffset.y > firstResponderFrameInScrollView.origin.y) {
+        contentOffset.y = firstResponderFrameInScrollView.origin.y;
+      }
+    }
+  }
+  
   [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
     self->_scrollView.contentInset = insets;
     self->_scrollView.scrollIndicatorInsets = insets;

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -34,7 +34,6 @@
 
 @interface WTRiPADSurveyViewController ()
 
-@property (nonatomic, assign) BOOL scrolled;
 @property (nonatomic, assign) int currentScore;
 @property (nonatomic, assign) BOOL alreadyVoted;
 @property (nonatomic, assign) CGFloat keyboardHeight;

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -296,21 +296,24 @@
 
 - (void)registerForKeyboardNotification {
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillShow:")
-                                               name:UIKeyboardWillShowNotification
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillHide:")
-                                               name:UIKeyboardWillHideNotification
+                                           selector:@selector(keyboardFrameChanging:)
+                                               name:UIKeyboardWillChangeFrameNotification
                                              object:nil];
 }
 
-- (void)keyboardWillShow:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:YES notification:notification];
-}
-
-- (void)keyboardWillHide:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:NO notification:notification];
+- (void)keyboardFrameChanging:(NSNotification *)notification {
+  CGRect keyboardFrameInWindow = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  CGRect scrollViewFrameInWindow = [_scrollView convertRect:_scrollView.bounds toView:nil];
+  CGRect overlap = CGRectIntersection(keyboardFrameInWindow, scrollViewFrameInWindow);
+  NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] floatValue];
+  UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
+  CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
+  
+  [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
+    self->_scrollView.contentInset = insets;
+    self->_scrollView.scrollIndicatorInsets = insets;
+    self->_scrollView.contentOffset = contentOffset;
+  } completion:nil];
 }
 
 - (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {


### PR DESCRIPTION
# Problems

I noticed that things get weird in the simulator if the software keyboard is disabled:

![simulator before change](https://thumbs.gfycat.com/NegligibleDizzyArmyworm-size_restricted.gif)


The scrolling in the scroll view as the keyboard is displayed lags a little behind the keyboard itself:

![little gap](https://thumbs.gfycat.com/PolishedUntimelyGhostshrimp-size_restricted.gif)


The feedback view does not show text input when the keyboard appears in iPhone landscape:

![off screen text](https://thumbs.gfycat.com/ReliableCooperativeCavy-size_restricted.gif)

# Fixes

I modified `WTRSurveyViewController` and `WTRiPADSurveyViewController` to use `UIKeyboardWillChangeFrameNotification` to calculate any `contentInset` needed to avoid the keyboard.  The iPhone view controller also takes into account the frame of the text view when deciding on a `contentOffset` for the scroll view, keeping the user's input visible.

![keyboard fixes 1](https://thumbs.gfycat.com/UnconsciousDiligentIndianpalmsquirrel-size_restricted.gif)

![landscape fix](https://thumbs.gfycat.com/AmusedAbsoluteGonolek-size_restricted.gif)


I'm also working on another branch to bring things up to date with iPhone X support and safe areas.