### PR TITLE
iPhone X support, more auto layout and less manual coord manipulation

### DIFF
--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */; };
 		7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */; };
 		7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */; };
+		96D67148204DC0CA00B2E887 /* UIView+SafeArea.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D67146204DC0CA00B2E887 /* UIView+SafeArea.h */; };
+		96D67149204DC0CA00B2E887 /* UIView+SafeArea.m in Sources */ = {isa = PBXBuildFile; fileRef = 96D67147204DC0CA00B2E887 /* UIView+SafeArea.m */; };
 		B2102A2D1BB59ABC0025DABC /* WTRDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = B2102A2B1BB59ABC0025DABC /* WTRDefaults.h */; };
 		B2102A2E1BB59ABC0025DABC /* WTRDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = B2102A2C1BB59ABC0025DABC /* WTRDefaults.m */; };
 		B2102A331BB59ACE0025DABC /* WTRCustomMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = B2102A2F1BB59ACE0025DABC /* WTRCustomMessages.h */; };
@@ -116,6 +118,8 @@
 		0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRDefaultsTests.m; sourceTree = "<group>"; };
 		7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FontAwesome.h"; sourceTree = "<group>"; };
 		7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FontAwesome.m"; sourceTree = "<group>"; };
+		96D67146204DC0CA00B2E887 /* UIView+SafeArea.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+SafeArea.h"; sourceTree = "<group>"; };
+		96D67147204DC0CA00B2E887 /* UIView+SafeArea.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+SafeArea.m"; sourceTree = "<group>"; };
 		B2102A2B1BB59ABC0025DABC /* WTRDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRDefaults.h; sourceTree = "<group>"; };
 		B2102A2C1BB59ABC0025DABC /* WTRDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRDefaults.m; sourceTree = "<group>"; };
 		B2102A2F1BB59ACE0025DABC /* WTRCustomMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRCustomMessages.h; sourceTree = "<group>"; };
@@ -343,6 +347,8 @@
 				B24550901B8E0188001AC1FB /* WTRColor.m */,
 				B2C940621BA30AFB00482494 /* UIImage+ImageFromColor.h */,
 				B2C940631BA30AFB00482494 /* UIImage+ImageFromColor.m */,
+				96D67146204DC0CA00B2E887 /* UIView+SafeArea.h */,
+				96D67147204DC0CA00B2E887 /* UIView+SafeArea.m */,
 				B229766B1BB0036100FC2772 /* WTRPropertiesParser.h */,
 				B229766C1BB0036100FC2772 /* WTRPropertiesParser.m */,
 			);
@@ -487,6 +493,7 @@
 				B23DEF7B1BBBE9CA002A7FFD /* WTRUserCustomMessages.h in Headers */,
 				B29A2E881BAC0B50007181D3 /* WTRFeedbackView.h in Headers */,
 				B2DC6F331B820E6B00F599B3 /* WTRApiClient.h in Headers */,
+				96D67148204DC0CA00B2E887 /* UIView+SafeArea.h in Headers */,
 				B2C940601BA300A000482494 /* WTRSlider.h in Headers */,
 				B278896D1BD914F2001D5696 /* SimpleConstraints.h in Headers */,
 			);
@@ -599,6 +606,7 @@
 				B268666F1BD5339800A4288D /* WTRiPADSurveyViewController.m in Sources */,
 				B2C940651BA30AFB00482494 /* UIImage+ImageFromColor.m in Sources */,
 				B2C9405C1BA0723300482494 /* WTRModalView.m in Sources */,
+				96D67149204DC0CA00B2E887 /* UIView+SafeArea.m in Sources */,
 				B26866771BD5444F00A4288D /* WTRiPADSurveyViewController+Constraints.m in Sources */,
 				B22976821BB2A2C300FC2772 /* WTRSocialShareView.m in Sources */,
 				B2DC6F2F1B82000900F599B3 /* Wootric.m in Sources */,

--- a/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.h
+++ b/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.h
@@ -27,12 +27,12 @@
 @interface NSLayoutConstraint (Simple)
 
 - (NSLayoutConstraint *)withConstant:(CGFloat)constant;
-- (NSLayoutConstraint *)toSecondViewTop:(UIView *)secondView;
-- (NSLayoutConstraint *)toSecondViewBottom:(UIView *)secondView;
-- (NSLayoutConstraint *)toSecondViewLeft:(UIView *)secondView;
-- (NSLayoutConstraint *)toSecondViewRight:(UIView *)secondView;
-- (NSLayoutConstraint *)toSecondViewCenterX:(UIView *)secondView;
-- (NSLayoutConstraint *)toSecondViewCenterY:(UIView *)secondView;
+- (NSLayoutConstraint *)toSecondItemTop:(id)secondItem;
+- (NSLayoutConstraint *)toSecondItemBottom:(id)secondItem;
+- (NSLayoutConstraint *)toSecondItemLeft:(id)secondItem;
+- (NSLayoutConstraint *)toSecondItemRight:(id)secondItem;
+- (NSLayoutConstraint *)toSecondItemCenterX:(id)secondItem;
+- (NSLayoutConstraint *)toSecondItemCenterY:(id)secondItem;
 - (void)addToView:(UIView *)view;
 - (void)addConstraint;
 

--- a/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.m
+++ b/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.m
@@ -42,11 +42,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewTop:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemTop:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeTop
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];
@@ -54,11 +54,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewBottom:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemBottom:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeBottom
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];
@@ -66,11 +66,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewLeft:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemLeft:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeLeft
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];
@@ -78,11 +78,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewRight:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemRight:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeRight
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];
@@ -90,11 +90,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewCenterX:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemCenterX:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeCenterX
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];
@@ -102,11 +102,11 @@
   return constraint;
 }
 
-- (NSLayoutConstraint *)toSecondViewCenterY:(UIView *)secondView {
+- (NSLayoutConstraint *)toSecondItemCenterY:(id)secondItem {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute
                                                                 relatedBy:self.relation
-                                                                   toItem:secondView
+                                                                   toItem:secondItem
                                                                 attribute:NSLayoutAttributeCenterY
                                                                multiplier:self.multiplier
                                                                  constant:self.constant];

--- a/WootricSDK/WootricSDK/UIView+SafeArea.h
+++ b/WootricSDK/WootricSDK/UIView+SafeArea.h
@@ -2,9 +2,25 @@
 //  UIView+SafeArea.h
 //  WootricSDK
 //
-//  Created by Jason Neel on 3/5/18.
-//  Copyright © 2018 Wootric. All rights reserved.
+// Copyright © 2018 Wootric. All rights reserved.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <UIKit/UIKit.h>
 

--- a/WootricSDK/WootricSDK/UIView+SafeArea.h
+++ b/WootricSDK/WootricSDK/UIView+SafeArea.h
@@ -1,0 +1,18 @@
+//
+//  UIView+SafeArea.h
+//  WootricSDK
+//
+//  Created by Jason Neel on 3/5/18.
+//  Copyright © 2018 Wootric. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (SafeArea)
+
+/**
+ *  Returns the safe area layout guide if available, otherwise self
+ */
+- (id) layoutAreaItemForConstraints;
+
+@end

--- a/WootricSDK/WootricSDK/UIView+SafeArea.m
+++ b/WootricSDK/WootricSDK/UIView+SafeArea.m
@@ -1,0 +1,24 @@
+//
+//  UIView+SafeArea.m
+//  WootricSDK
+//
+//  Created by Jason Neel on 3/5/18.
+//  Copyright © 2018 Wootric. All rights reserved.
+//
+
+#import "UIView+SafeArea.h"
+
+@implementation UIView (SafeArea)
+
+/**
+ *  Returns the safe area layout guide if available, otherwise self
+ */
+- (id) layoutAreaItemForConstraints {
+  if (@available(iOS 11.0, *)) {
+    return self.safeAreaLayoutGuide;
+  }
+  
+  return self;
+}
+
+@end

--- a/WootricSDK/WootricSDK/UIView+SafeArea.m
+++ b/WootricSDK/WootricSDK/UIView+SafeArea.m
@@ -2,9 +2,25 @@
 //  UIView+SafeArea.m
 //  WootricSDK
 //
-//  Created by Jason Neel on 3/5/18.
-//  Copyright © 2018 Wootric. All rights reserved.
+// Copyright © 2018 Wootric. All rights reserved.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "UIView+SafeArea.h"
 

--- a/WootricSDK/WootricSDK/WTRFeedbackView.h
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.h
@@ -38,4 +38,11 @@
 - (BOOL)feedbackTextPresent;
 - (BOOL)isActive;
 
+/**
+ *  If this view has an active first responder (e.g. the feedback text field), this provides the rect within
+ *   the WTRFeedbackView bounds for that view.
+ *  Returns CGRectNull if there is no first responder within this view.
+ */
+- (CGRect)frameForFirstResponder;
+
 @end

--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -27,6 +27,7 @@
 #import "WTRSurveyViewController.h"
 #import "SimpleConstraints.h"
 #import "UIItems.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRFeedbackView ()
 
@@ -128,22 +129,25 @@
 }
 
 - (void)setupEditScoreButtonConstraints {
-  [[[_editScoreButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
-  [[[[_editScoreButton wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[_editScoreButton wtr_centerXConstraint] toSecondItemCenterX:layoutArea] addToView:self];
+  [[[[_editScoreButton wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:16] addToView:self];
 }
 
 - (void)setupFollowupLabelConstraints {
-  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
-  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:self] withConstant:50] addToView:self];
-  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
-  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:layoutArea] addToView:self];
+  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:50] addToView:self];
+  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:16] addToView:self];
+  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-16] addToView:self];
 }
 
 - (void)setupFeedbackTextViewConstraints {
-  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
-  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:16] addToView:self];
+  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-16] addToView:self];
   [[[[_feedbackTextView wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:16] addToView:self];
-  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
+  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:layoutArea] addToView:self];
 }
 
 - (void)setupFeedbackLabelConstraints {

--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -128,28 +128,28 @@
 }
 
 - (void)setupEditScoreButtonConstraints {
-  [[[_editScoreButton wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_editScoreButton wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
+  [[[_editScoreButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_editScoreButton wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
 }
 
 - (void)setupFollowupLabelConstraints {
-  [[[_followupLabel wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_followupLabel wtr_topConstraint] toSecondViewTop:self] withConstant:50] addToView:self];
-  [[[[_followupLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:16] addToView:self];
-  [[[[_followupLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-16] addToView:self];
+  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:self] withConstant:50] addToView:self];
+  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
+  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
 }
 
 - (void)setupFeedbackTextViewConstraints {
-  [[[[_feedbackTextView wtr_leftConstraint] toSecondViewLeft:self] withConstant:16] addToView:self];
-  [[[[_feedbackTextView wtr_rightConstraint] toSecondViewRight:self] withConstant:-16] addToView:self];
-  [[[[_feedbackTextView wtr_topConstraint] toSecondViewBottom:_followupLabel] withConstant:16] addToView:self];
-  [[[_feedbackTextView wtr_bottomConstraint] toSecondViewBottom:self] addToView:self];
+  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
+  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
+  [[[[_feedbackTextView wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:16] addToView:self];
+  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
 }
 
 - (void)setupFeedbackLabelConstraints {
-  [[[[_feedbackPlaceholder wtr_leftConstraint] toSecondViewLeft:_feedbackTextView] withConstant:20] addToView:self];
-  [[[[_feedbackPlaceholder wtr_rightConstraint] toSecondViewRight:_feedbackTextView] withConstant:-20] addToView:self];
-  [[[[_feedbackPlaceholder wtr_topConstraint] toSecondViewTop:_feedbackTextView] withConstant:17] addToView:self];
+  [[[[_feedbackPlaceholder wtr_leftConstraint] toSecondItemLeft:_feedbackTextView] withConstant:20] addToView:self];
+  [[[[_feedbackPlaceholder wtr_rightConstraint] toSecondItemRight:_feedbackTextView] withConstant:-20] addToView:self];
+  [[[[_feedbackPlaceholder wtr_topConstraint] toSecondItemTop:_feedbackTextView] withConstant:17] addToView:self];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -96,6 +96,15 @@
   return !self.hidden;
 }
 
+- (CGRect)frameForFirstResponder
+{
+  if (_feedbackTextView.isFirstResponder) {
+    return _feedbackTextView.frame;
+  }
+  
+  return CGRectZero;
+}
+
 - (void)setupEditScoreButtonWithViewController:(UIViewController *)viewController {
   _editScoreButton = [[UIButton alloc] init];
   _editScoreButton.titleLabel.font = [UIFont boldSystemFontOfSize:12];

--- a/WootricSDK/WootricSDK/WTRQuestionView.h
+++ b/WootricSDK/WootricSDK/WTRQuestionView.h
@@ -31,7 +31,6 @@
 
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
 - (void)setupSubviewsConstraints;
-- (void)recalculateDotsAndScorePositionForWidth:(CGFloat)widthAfterRotation;
 - (void)addDotsAndScores;
 - (void)sliderTapped:(UIGestureRecognizer *)gestureRecognizer;
 - (int)getScoreSliderValue;

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -27,6 +27,7 @@
 #import "WTRScoreView.h"
 #import "WTRSlider.h"
 #import "UIItems.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRQuestionView ()
 
@@ -109,17 +110,6 @@
   [self setupScoreLabelConstraints];
   [self setupLikelyAnchorConstraints];
   [self setupNotLikelyAnchorConstraints];
-}
-
-/**
- *  Returns the safe area layout guide if available, otherwise self
- */
-- (id) layoutAreaItemForConstraints {
-  if (@available(iOS 11.0, *)) {
-    return self.safeAreaLayoutGuide;
-  }
-  
-  return self;
 }
 
 #pragma mark - Subviews setup

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -111,6 +111,17 @@
   [self setupNotLikelyAnchorConstraints];
 }
 
+/**
+ *  Returns the safe area layout guide if available, otherwise self
+ */
+- (id) layoutAreaItemForConstraints {
+  if (@available(iOS 11.0, *)) {
+    return self.safeAreaLayoutGuide;
+  }
+  
+  return self;
+}
+
 #pragma mark - Subviews setup
 
 - (void)setupQuestionLabel {
@@ -192,7 +203,6 @@
 }
 
 - (void)setupQuestionLabelConstraints {
-  //  CGFloat topMargin = [self isSmallerScreenDevice] ? 30 : 40;
   NSLayoutConstraint *constTop = [NSLayoutConstraint constraintWithItem:_questionLabel
                                                               attribute:NSLayoutAttributeTop
                                                               relatedBy:NSLayoutRelationEqual
@@ -202,7 +212,6 @@
                                                                constant:16];
   [self addConstraint:constTop];
 
-  //  CGFloat margin = [self isSmallerScreenDevice] ? 20 : 50;
   NSLayoutConstraint *constLeft = [NSLayoutConstraint constraintWithItem:_questionLabel
                                                                attribute:NSLayoutAttributeLeft
                                                                relatedBy:NSLayoutRelationEqual
@@ -226,7 +235,7 @@
   NSLayoutConstraint *constX = [NSLayoutConstraint constraintWithItem:_scoreSlider
                                                             attribute:NSLayoutAttributeCenterX
                                                             relatedBy:NSLayoutRelationEqual
-                                                               toItem:self
+                                                               toItem:[self layoutAreaItemForConstraints]
                                                             attribute:NSLayoutAttributeCenterX
                                                            multiplier:1
                                                              constant:0];
@@ -244,7 +253,7 @@
   NSLayoutConstraint *constRight = [NSLayoutConstraint constraintWithItem:_scoreSlider
                                                                 attribute:NSLayoutAttributeRight
                                                                 relatedBy:NSLayoutRelationEqual
-                                                                   toItem:self
+                                                                   toItem:[self layoutAreaItemForConstraints]
                                                                 attribute:NSLayoutAttributeRight
                                                                multiplier:1
                                                                  constant:-17];
@@ -254,7 +263,7 @@
   NSLayoutConstraint *constLeft = [NSLayoutConstraint constraintWithItem:_scoreSlider
                                                                attribute:NSLayoutAttributeLeft
                                                                relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self
+                                                                  toItem:[self layoutAreaItemForConstraints]
                                                                attribute:NSLayoutAttributeLeft
                                                               multiplier:1
                                                                 constant:17];
@@ -275,7 +284,7 @@
   NSLayoutConstraint *constRight = [NSLayoutConstraint constraintWithItem:_scoreLabel
                                                                 attribute:NSLayoutAttributeRight
                                                                 relatedBy:NSLayoutRelationEqual
-                                                                   toItem:self
+                                                                   toItem:[self layoutAreaItemForConstraints]
                                                                 attribute:NSLayoutAttributeRight
                                                                multiplier:1
                                                                  constant:-15];
@@ -285,7 +294,7 @@
   NSLayoutConstraint *constLeft = [NSLayoutConstraint constraintWithItem:_scoreLabel
                                                                attribute:NSLayoutAttributeLeft
                                                                relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self
+                                                                  toItem:[self layoutAreaItemForConstraints]
                                                                attribute:NSLayoutAttributeLeft
                                                               multiplier:1
                                                                 constant:15];

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -116,8 +116,11 @@
 
 - (void)setupQuestionLabel {
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     _questionLabel = [UIItems questionLabelWithSettings:_settings
                                                       andFont:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
+#pragma clang diagnostic pop
   } else {
     _questionLabel = [UIItems questionLabelWithSettings:_settings
                                                       andFont:[UIFont systemFontOfSize:18]];

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -55,11 +55,6 @@
   return self;
 }
 
-- (void)recalculateDotsAndScorePositionForWidth:(CGFloat)widthAfterRotation {
-  [_scoreSlider recalculateDotsPositionForSliderWidth:widthAfterRotation];
-  [_scoreLabel recalculateScorePositionForScoreLabelWidth:widthAfterRotation];
-}
-
 - (void)addDotsAndScores {
   [_scoreSlider addDots];
   [_scoreLabel addScores];

--- a/WootricSDK/WootricSDK/WTRScoreView.h
+++ b/WootricSDK/WootricSDK/WTRScoreView.h
@@ -30,7 +30,6 @@
 - (instancetype)initWithSettings:(WTRSettings *)settings color:(UIColor *)color;
 
 - (void)addScores;
-- (void)recalculateScorePositionForScoreLabelWidth:(CGFloat)scoreLabelWidth;
 - (void)highlightCurrentScore:(int)score;
 
 @end

--- a/WootricSDK/WootricSDK/WTRScoreView.m
+++ b/WootricSDK/WootricSDK/WTRScoreView.m
@@ -79,20 +79,46 @@ static const CGFloat EndNumbersDistanceCenterToEdge = 10.0;
     [self addSubview:label];
     [newLabels addObject:label];
     
-    NSLayoutConstraint * centerY = [NSLayoutConstraint constraintWithItem:label attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * centerY = [NSLayoutConstraint constraintWithItem:label
+                                                                attribute:NSLayoutAttributeCenterY
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeCenterY
+                                                               multiplier:1.0
+                                                                 constant:0.0];
     [self addConstraint:centerY];
     
     if (firstLabel == nil) {
       firstLabel = label;
     } else {
-      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:label attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:firstLabel attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:label
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:firstLabel
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:1.0
+                                                                     constant:0.0];
       [self addConstraint:sameWidth];
     }
   }
   
   // Pin leftmost and rightmost labels to edges
-  NSLayoutConstraint * leftmostLabelLeftness = [NSLayoutConstraint constraintWithItem:[newLabels firstObject] attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:EndNumbersDistanceCenterToEdge];
-  NSLayoutConstraint * rightmostLabelRightness = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:[newLabels lastObject] attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:EndNumbersDistanceCenterToEdge];
+  NSLayoutConstraint * leftmostLabelLeftness = [NSLayoutConstraint constraintWithItem:[newLabels firstObject]
+                                                                            attribute:NSLayoutAttributeCenterX
+                                                                            relatedBy:NSLayoutRelationEqual
+                                                                               toItem:self
+                                                                            attribute:NSLayoutAttributeLeft
+                                                                           multiplier:1.0
+                                                                             constant:EndNumbersDistanceCenterToEdge];
+  
+  NSLayoutConstraint * rightmostLabelRightness = [NSLayoutConstraint constraintWithItem:self
+                                                                              attribute:NSLayoutAttributeRight
+                                                                              relatedBy:NSLayoutRelationEqual
+                                                                                 toItem:[newLabels lastObject]
+                                                                              attribute:NSLayoutAttributeCenterX
+                                                                             multiplier:1.0
+                                                                               constant:EndNumbersDistanceCenterToEdge];
+  
   [self addConstraints:@[leftmostLabelLeftness, rightmostLabelRightness]];
   
   // Put spacers between labels
@@ -108,18 +134,45 @@ static const CGFloat EndNumbersDistanceCenterToEdge = 10.0;
     [self addSubview:spacer];
     
     // 1 pt tall for no particular reason
-    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:1.0];
+    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:spacer
+                                                               attribute:NSLayoutAttributeHeight
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:nil
+                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                              multiplier:1.0
+                                                                constant:1.0];
     
     // Hold them both
-    NSLayoutConstraint * leftHandhold = [NSLayoutConstraint constraintWithItem:leftLabel attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:spacer attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * rightHandhold = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:rightLabel attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * leftHandhold = [NSLayoutConstraint constraintWithItem:leftLabel
+                                                                     attribute:NSLayoutAttributeCenterX
+                                                                     relatedBy:NSLayoutRelationEqual
+                                                                        toItem:spacer
+                                                                     attribute:NSLayoutAttributeLeft
+                                                                    multiplier:1.0
+                                                                      constant:0.0];
+    
+    NSLayoutConstraint * rightHandhold = [NSLayoutConstraint constraintWithItem:spacer
+                                                                      attribute:NSLayoutAttributeRight
+                                                                      relatedBy:NSLayoutRelationEqual
+                                                                         toItem:rightLabel
+                                                                      attribute:NSLayoutAttributeCenterX
+                                                                     multiplier:1.0
+                                                                       constant:0.0];
+    
     [self addConstraints:@[height, leftHandhold, rightHandhold]];
     
     // Same widths
     if (i == 0) {
       firstSpacer = spacer;
     } else {
-      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:firstSpacer attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:spacer
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:firstSpacer
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:1.0
+                                                                     constant:0.0];
+      
       [self addConstraint:sameWidth];
     }
     

--- a/WootricSDK/WootricSDK/WTRScoreView.m
+++ b/WootricSDK/WootricSDK/WTRScoreView.m
@@ -26,7 +26,7 @@
 #import "WTRSingleScoreLabel.h"
 #import "WTRColor.h"
 
-static const CGFloat SideMargin = 8.0;
+static const CGFloat SideMargin = 6.0;
 
 @interface WTRScoreView ()
 
@@ -71,6 +71,7 @@ static const CGFloat SideMargin = 8.0;
   
   NSMutableArray<WTRSingleScoreLabel *> * newLabels = [[NSMutableArray alloc] initWithCapacity:labelCount];
   NSMutableArray<UIView *> * newSpacers = [[NSMutableArray alloc] initWithCapacity:labelCount - 1];
+  WTRSingleScoreLabel * firstLabel = nil;
   
   for (int i = _settings.minimumScore; i <= _settings.maximumScore; i++) {
     WTRSingleScoreLabel * label = [[WTRSingleScoreLabel alloc] initWithColor:_labelColor];
@@ -80,6 +81,13 @@ static const CGFloat SideMargin = 8.0;
     
     NSLayoutConstraint * centerY = [NSLayoutConstraint constraintWithItem:label attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0.0];
     [self addConstraint:centerY];
+    
+    if (firstLabel == nil) {
+      firstLabel = label;
+    } else {
+      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:label attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:firstLabel attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+      [self addConstraint:sameWidth];
+    }
   }
   
   // Pin leftmost and rightmost labels to edges

--- a/WootricSDK/WootricSDK/WTRScoreView.m
+++ b/WootricSDK/WootricSDK/WTRScoreView.m
@@ -26,7 +26,7 @@
 #import "WTRSingleScoreLabel.h"
 #import "WTRColor.h"
 
-static const CGFloat SideMargin = 6.0;
+static const CGFloat EndNumbersDistanceCenterToEdge = 10.0;
 
 @interface WTRScoreView ()
 
@@ -91,8 +91,8 @@ static const CGFloat SideMargin = 6.0;
   }
   
   // Pin leftmost and rightmost labels to edges
-  NSLayoutConstraint * leftmostLabelLeftness = [NSLayoutConstraint constraintWithItem:[newLabels firstObject] attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:SideMargin];
-  NSLayoutConstraint * rightmostLabelRightness = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:[newLabels lastObject] attribute:NSLayoutAttributeRight multiplier:1.0 constant:SideMargin];
+  NSLayoutConstraint * leftmostLabelLeftness = [NSLayoutConstraint constraintWithItem:[newLabels firstObject] attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:EndNumbersDistanceCenterToEdge];
+  NSLayoutConstraint * rightmostLabelRightness = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:[newLabels lastObject] attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:EndNumbersDistanceCenterToEdge];
   [self addConstraints:@[leftmostLabelLeftness, rightmostLabelRightness]];
   
   // Put spacers between labels
@@ -111,8 +111,8 @@ static const CGFloat SideMargin = 6.0;
     NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:1.0];
     
     // Hold them both
-    NSLayoutConstraint * leftHandhold = [NSLayoutConstraint constraintWithItem:leftLabel attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:spacer attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * rightHandhold = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:rightLabel attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * leftHandhold = [NSLayoutConstraint constraintWithItem:leftLabel attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:spacer attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * rightHandhold = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:rightLabel attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
     [self addConstraints:@[height, leftHandhold, rightHandhold]];
     
     // Same widths

--- a/WootricSDK/WootricSDK/WTRSingleScoreLabel.h
+++ b/WootricSDK/WootricSDK/WTRSingleScoreLabel.h
@@ -30,7 +30,6 @@
 
 - (instancetype)initWithColor:(UIColor *)color;
 
-- (void)addConstraintsWithLeftConstraintConstant:(CGFloat)leftConstant;
 - (void)setAsSelected;
 - (void)setAsUnselected;
 

--- a/WootricSDK/WootricSDK/WTRSingleScoreLabel.m
+++ b/WootricSDK/WootricSDK/WTRSingleScoreLabel.m
@@ -59,22 +59,4 @@
   self.font = [UIFont systemFontOfSize:16];
 }
 
-- (void)addConstraintsWithLeftConstraintConstant:(CGFloat)leftConstant {
-  UIView *superView = self.superview;
-
-  self.leftConstraint = [NSLayoutConstraint constraintWithItem:self
-                                                     attribute:NSLayoutAttributeCenterX
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:superView
-                                                     attribute:NSLayoutAttributeLeft
-                                                    multiplier:1
-                                                      constant:leftConstant];
-
-  [superView addConstraint:self.leftConstraint];
-
-  [[[self wtr_centerYConstraint] toSecondViewCenterY:superView] addToView:superView];
-  [self wtr_constraintWidth:24];
-  [self wtr_constraintHeight:16];
-}
-
 @end

--- a/WootricSDK/WootricSDK/WTRSlider.h
+++ b/WootricSDK/WootricSDK/WTRSlider.h
@@ -32,7 +32,6 @@
 - (instancetype)initWithSuperview:(UIView *)superview viewController:(UIViewController *)viewController settings:(WTRSettings *)settings;
 - (instancetype)initWithSuperview:(UIView *)superview viewController:(UIViewController *)viewController settings: (WTRSettings *)settings color:(UIColor *)color;
 - (void)addDots;
-- (void)recalculateDotsPositionForSliderWidth:(CGFloat)sliderWidth;
 - (void)updateDots;
 - (void)showThumb;
 - (void)tappedAtPoint:(CGPoint)point;

--- a/WootricSDK/WootricSDK/WTRSlider.m
+++ b/WootricSDK/WootricSDK/WTRSlider.m
@@ -32,7 +32,6 @@ static const CGFloat ThumbSize = 24.0;
 
 @interface WTRSlider ()
 
-@property (nonatomic, assign) int currentValue;
 @property (nonatomic, strong) UIColor *sliderColor;
 @property (nonatomic, strong) WTRSettings *settings;
 
@@ -53,7 +52,6 @@ static const CGFloat ThumbSize = 24.0;
   if (self = [super init]) {
     _settings = settings;
     _sliderColor = color;
-    _currentValue = -1;
     
     self.minimumValue = [_settings minimumScore];
     self.maximumValue = [_settings maximumScore];

--- a/WootricSDK/WootricSDK/WTRSlider.m
+++ b/WootricSDK/WootricSDK/WTRSlider.m
@@ -89,11 +89,6 @@ static const CGFloat ThumbSize = 24.0;
   }
 }
 
-- (NSUInteger) numberOfDots
-{
-  return (self.maximumValue - self.minimumValue + 1);
-}
-
 - (void)addDots {
   // Remove any previous dots
   [dots enumerateObjectsUsingBlock:^(WTRSliderDot * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -104,7 +99,7 @@ static const CGFloat ThumbSize = 24.0;
   }];
   
   // Sanity check
-  NSUInteger dotCount = [self numberOfDots];
+  NSUInteger dotCount = self.maximumValue - self.minimumValue + 1;
   if (dotCount < 2) {
     return;
   }

--- a/WootricSDK/WootricSDK/WTRSlider.m
+++ b/WootricSDK/WootricSDK/WTRSlider.m
@@ -113,16 +113,51 @@ static const CGFloat ThumbSize = 24.0;
     [self addSubview:dot];
     [self bringSubviewToFront:dot];
     
-    NSLayoutConstraint * centerY = [NSLayoutConstraint constraintWithItem:dot attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * width = [NSLayoutConstraint constraintWithItem:dot attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:DotRadius];
-    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:dot attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:DotRadius];
+    NSLayoutConstraint * centerY = [NSLayoutConstraint constraintWithItem:dot
+                                                                attribute:NSLayoutAttributeCenterY
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeCenterY
+                                                               multiplier:1.0
+                                                                 constant:0.0];
+    
+    NSLayoutConstraint * width = [NSLayoutConstraint constraintWithItem:dot
+                                                              attribute:NSLayoutAttributeWidth
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:nil
+                                                              attribute:NSLayoutAttributeNotAnAttribute
+                                                             multiplier:1.0
+                                                               constant:DotRadius];
+    
+    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:dot
+                                                               attribute:NSLayoutAttributeHeight
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:nil
+                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                              multiplier:1.0
+                                                                constant:DotRadius];
+    
     [self addConstraints:@[centerY, width, height]];
   }
 
   // Pin edge dots to edges
   CGFloat margin = DotRadius;
-  NSLayoutConstraint * leftmostDotLeftness = [NSLayoutConstraint constraintWithItem:[newDots firstObject] attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:margin];
-  NSLayoutConstraint * rightmostDotRightness = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:[newDots lastObject] attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:margin];
+  NSLayoutConstraint * leftmostDotLeftness = [NSLayoutConstraint constraintWithItem:[newDots firstObject]
+                                                                          attribute:NSLayoutAttributeCenterX
+                                                                          relatedBy:NSLayoutRelationEqual
+                                                                             toItem:self
+                                                                          attribute:NSLayoutAttributeLeft
+                                                                         multiplier:1.0
+                                                                           constant:margin];
+  
+  NSLayoutConstraint * rightmostDotRightness = [NSLayoutConstraint constraintWithItem:self
+                                                                            attribute:NSLayoutAttributeRight
+                                                                            relatedBy:NSLayoutRelationEqual
+                                                                               toItem:[newDots lastObject]
+                                                                            attribute:NSLayoutAttributeCenterX
+                                                                           multiplier:1.0
+                                                                             constant:margin];
+  
   [self addConstraints:@[leftmostDotLeftness, rightmostDotRightness]];
   
   // Put invisible spacers between dots
@@ -140,18 +175,45 @@ static const CGFloat ThumbSize = 24.0;
     [newDotSpacers addObject:spacer];
     
     // 1 pt tall for no particular reason
-    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:1.0];
+    NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:spacer
+                                                               attribute:NSLayoutAttributeHeight
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:nil
+                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                              multiplier:1.0
+                                                                constant:1.0];
     
     // Hold on to those dots
-    NSLayoutConstraint * leftDotHandhold = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:leftDot attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * rightDotHandhold = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:rightDot attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * leftDotHandhold = [NSLayoutConstraint constraintWithItem:spacer
+                                                                        attribute:NSLayoutAttributeLeft
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:leftDot
+                                                                        attribute:NSLayoutAttributeRight
+                                                                       multiplier:1.0
+                                                                         constant:0.0];
+    
+    NSLayoutConstraint * rightDotHandhold = [NSLayoutConstraint constraintWithItem:spacer
+                                                                         attribute:NSLayoutAttributeRight
+                                                                         relatedBy:NSLayoutRelationEqual
+                                                                            toItem:rightDot
+                                                                         attribute:NSLayoutAttributeLeft
+                                                                        multiplier:1.0
+                                                                          constant:0.0];
+    
     [self addConstraints:@[height, leftDotHandhold, rightDotHandhold]];
 
     // Same width for all spacers
     if (i == 0) {
       firstSpacer = spacer;
     } else {
-      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:spacer attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:firstSpacer attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+      NSLayoutConstraint * sameWidth = [NSLayoutConstraint constraintWithItem:spacer
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:firstSpacer
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:1.0
+                                                                     constant:0.0];
+      
       [self addConstraint:sameWidth];
     }
   }

--- a/WootricSDK/WootricSDK/WTRSliderDot.h
+++ b/WootricSDK/WootricSDK/WTRSliderDot.h
@@ -30,7 +30,6 @@
 
 - (instancetype)initWithColor:(UIColor *)color;
 
-- (void)addConstraintsWithLeftConstraintConstant:(CGFloat)leftConstant;
 - (void)setAsSelected;
 - (void)setAsUnselected;
 

--- a/WootricSDK/WootricSDK/WTRSliderDot.m
+++ b/WootricSDK/WootricSDK/WTRSliderDot.m
@@ -60,46 +60,4 @@
   self.layer.borderColor = [WTRColor sliderDotBorderColor].CGColor;
 }
 
-- (void)addConstraintsWithLeftConstraintConstant:(CGFloat)leftConstant {
-  UIView *superView = self.superview;
-
-  self.leftConstraint = [NSLayoutConstraint constraintWithItem:self
-                                                     attribute:NSLayoutAttributeCenterX
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:superView
-                                                     attribute:NSLayoutAttributeLeft
-                                                    multiplier:1
-                                                      constant:leftConstant];
-
-  [superView addConstraint:self.leftConstraint];
-
-  NSLayoutConstraint *constY = [NSLayoutConstraint constraintWithItem:self
-                                                            attribute:NSLayoutAttributeCenterY
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:superView
-                                                            attribute:NSLayoutAttributeCenterY
-                                                           multiplier:1
-                                                             constant:0];
-
-  [superView addConstraint:constY];
-
-  NSLayoutConstraint *constW = [NSLayoutConstraint constraintWithItem:self
-                                                            attribute:NSLayoutAttributeWidth
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:nil
-                                                            attribute:NSLayoutAttributeNotAnAttribute
-                                                           multiplier:1
-                                                             constant:8];
-  [self addConstraint:constW];
-
-  NSLayoutConstraint *constH = [NSLayoutConstraint constraintWithItem:self
-                                                            attribute:NSLayoutAttributeHeight
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:nil
-                                                            attribute:NSLayoutAttributeNotAnAttribute
-                                                           multiplier:1
-                                                             constant:8];
-  [self addConstraint:constH];
-}
-
 @end

--- a/WootricSDK/WootricSDK/WTRSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.m
@@ -162,9 +162,12 @@
 
 - (void)setupFinalThankYouLabel {
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     _finalThankYouLabel = [UIItems finalThankYouLabelWithSettings:_settings
                                                         textColor:[UIColor blackColor]
                                                           andFont:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
+#pragma clang diagnostic pop
   } else {
     _finalThankYouLabel = [UIItems finalThankYouLabelWithSettings:_settings
                                                         textColor:[UIColor blackColor]

--- a/WootricSDK/WootricSDK/WTRSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.m
@@ -183,15 +183,15 @@
 }
 
 - (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_customThankYouLabel wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:8] addToView:self];
+  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  [[[[_customThankYouLabel wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:8] addToView:self];
 }
 
 - (void)setupFacebookButtonConstraints {
   [_facebookButton wtr_constraintWidth:32];
   [_facebookButton wtr_constraintHeight:32];
-  [[[[_facebookButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+  [[[[_facebookButton wtr_topConstraint] toSecondItemBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
 
   _facebookXConstraint = [NSLayoutConstraint constraintWithItem:_facebookButton
                                                       attribute:NSLayoutAttributeCenterX
@@ -206,7 +206,7 @@
 - (void)setupTwitterButtonConstraints {
   [_twitterButton wtr_constraintWidth:32];
   [_twitterButton wtr_constraintHeight:32];
-  [[[[_twitterButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+  [[[[_twitterButton wtr_topConstraint] toSecondItemBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
 
   _twitterXConstraint = [NSLayoutConstraint constraintWithItem:_twitterButton
                                                      attribute:NSLayoutAttributeCenterX
@@ -221,7 +221,7 @@
 - (void)setupFacebookLikeButtonConstraints {
     [_facebookLikeButton wtr_constraintWidth:32];
     [_facebookLikeButton wtr_constraintHeight:32];
-    [[[[_facebookLikeButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+    [[[[_facebookLikeButton wtr_topConstraint] toSecondItemBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
     
     _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
                                                         attribute:NSLayoutAttributeCenterX
@@ -234,28 +234,28 @@
 }
 
 - (void)setupSocialShareQuestionLabelConstraints {
-  [[[[_socialShareQuestionLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_socialShareQuestionLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_socialShareQuestionLabel wtr_topConstraint] toSecondViewBottom:_thankYouButton] withConstant:16] addToView:self];
+  [[[[_socialShareQuestionLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[_socialShareQuestionLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  [[[[_socialShareQuestionLabel wtr_topConstraint] toSecondItemBottom:_thankYouButton] withConstant:16] addToView:self];
 }
 
 - (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[self wtr_rightConstraint] toSecondViewRight:_finalThankYouLabel] withConstant:24] addToView:self];
+  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
+  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[self wtr_rightConstraint] toSecondItemRight:_finalThankYouLabel] withConstant:24] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {
   [_thankYouButton wtr_constraintHeight:50];
-  [[[_thankYouButton wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_thankYouButton wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_thankYouButton wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_thankYouButton wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:38] addToView:self];
+  [[[_thankYouButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_thankYouButton wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[_thankYouButton wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  [[[[_thankYouButton wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:38] addToView:self];
 }
 
 - (void)setupNoThanksButtonConstraints {
-  [[[_noThanksButton wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_noThanksButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-8] addToView:self];
+  [[[_noThanksButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-8] addToView:self];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.m
@@ -28,6 +28,7 @@
 #import "NSString+FontAwesome.h"
 #import "SimpleConstraints.h"
 #import "UIItems.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRSocialShareView ()
 
@@ -183,8 +184,9 @@
 }
 
 - (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
+  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-24] addToView:self];
   [[[[_customThankYouLabel wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:8] addToView:self];
 }
 
@@ -196,7 +198,7 @@
   _facebookXConstraint = [NSLayoutConstraint constraintWithItem:_facebookButton
                                                       attribute:NSLayoutAttributeCenterX
                                                       relatedBy:NSLayoutRelationEqual
-                                                         toItem:self
+                                                         toItem:[self layoutAreaItemForConstraints]
                                                       attribute:NSLayoutAttributeCenterX
                                                      multiplier:1
                                                        constant:0];
@@ -211,7 +213,7 @@
   _twitterXConstraint = [NSLayoutConstraint constraintWithItem:_twitterButton
                                                      attribute:NSLayoutAttributeCenterX
                                                      relatedBy:NSLayoutRelationEqual
-                                                        toItem:self
+                                                        toItem:[self layoutAreaItemForConstraints]
                                                      attribute:NSLayoutAttributeCenterX
                                                     multiplier:1
                                                       constant:0];
@@ -226,7 +228,7 @@
     _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
                                                         attribute:NSLayoutAttributeCenterX
                                                         relatedBy:NSLayoutRelationEqual
-                                                           toItem:self
+                                                           toItem:[self layoutAreaItemForConstraints]
                                                         attribute:NSLayoutAttributeCenterX
                                                        multiplier:1
                                                          constant:0];
@@ -234,28 +236,32 @@
 }
 
 - (void)setupSocialShareQuestionLabelConstraints {
-  [[[[_socialShareQuestionLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
-  [[[[_socialShareQuestionLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_socialShareQuestionLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
+  [[[[_socialShareQuestionLabel wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-24] addToView:self];
   [[[[_socialShareQuestionLabel wtr_topConstraint] toSecondItemBottom:_thankYouButton] withConstant:16] addToView:self];
 }
 
 - (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:16] addToView:self];
+  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
   [[[[self wtr_rightConstraint] toSecondItemRight:_finalThankYouLabel] withConstant:24] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_thankYouButton wtr_constraintHeight:50];
-  [[[_thankYouButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
-  [[[[_thankYouButton wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
-  [[[[_thankYouButton wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  [[[_thankYouButton wtr_centerXConstraint] toSecondItemCenterX:layoutArea] addToView:self];
+  [[[[_thankYouButton wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
+  [[[[_thankYouButton wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-24] addToView:self];
   [[[[_thankYouButton wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:38] addToView:self];
 }
 
 - (void)setupNoThanksButtonConstraints {
-  [[[_noThanksButton wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
-  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-8] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[_noThanksButton wtr_centerXConstraint] toSecondItemCenterX:layoutArea] addToView:self];
+  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-8] addToView:self];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
@@ -232,7 +232,6 @@
 
 - (void)setupScrollContentViewConstraints {
   // The scroll content view will be at least as large as the scroll view itself.  It can expand to be taller.
-  
   NSDictionary * views = @{@"scrollContentView": self.scrollContentView};
   NSArray<NSLayoutConstraint *> * horizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollContentView]|" options:0 metrics:nil views:views];
   [self.scrollView addConstraints:horizontalConstraints];

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
@@ -247,15 +247,6 @@
                                                              constant:308];
   [self.modalView addConstraint:self.constraintModalHeight];
 
-  NSLayoutConstraint *constX = [NSLayoutConstraint constraintWithItem:self.modalView
-                                                            attribute:NSLayoutAttributeCenterX
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:self.view
-                                                            attribute:NSLayoutAttributeCenterX
-                                                           multiplier:1
-                                                             constant:0];
-  [self.view addConstraint:constX];
-
   NSLayoutConstraint *constB = [NSLayoutConstraint constraintWithItem:self.modalView
                                                             attribute:NSLayoutAttributeBottom
                                                             relatedBy:NSLayoutRelationEqual

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
@@ -23,11 +23,13 @@
 // THE SOFTWARE.
 
 #import "WTRSurveyViewController+Constraints.h"
+#import "UIView+SafeArea.h"
 
 @implementation WTRSurveyViewController (Constraints)
 
 - (void)setupConstraints {
   [self setupScrollViewConstraints];
+  [self setupScrollContentViewConstraints];
   [self setupModalConstraints];
   [self setupQuestionViewConstraints];
   [self.questionView setupSubviewsConstraints];
@@ -228,6 +230,56 @@
   [self.feedbackView addConstraint:constH];
 }
 
+- (void)setupScrollContentViewConstraints {
+  // The scroll content view will be at least as large as the scroll view itself.  It can expand to be taller.
+  
+  NSDictionary * views = @{@"scrollContentView": self.scrollContentView};
+  NSArray<NSLayoutConstraint *> * horizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollContentView]|" options:0 metrics:nil views:views];
+  [self.scrollView addConstraints:horizontalConstraints];
+  
+  // Stuck to bottom
+  NSLayoutConstraint * bottom = [NSLayoutConstraint constraintWithItem:self.scrollContentView
+                                                             attribute:NSLayoutAttributeBottom
+                                                             relatedBy:NSLayoutRelationEqual
+                                                                toItem:self.scrollView
+                                                             attribute:NSLayoutAttributeBottom
+                                                            multiplier:1.0
+                                                              constant:0.0];
+  [self.scrollView addConstraint:bottom];
+  
+  // Stick to the scroll content to the top of the scroll view.  The lower priority allows this constraint to be
+  //  broken when the modal view grows taller than the scroll view.
+  NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:self.scrollContentView
+                                                          attribute:NSLayoutAttributeTop
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:self.scrollView
+                                                          attribute:NSLayoutAttributeTop
+                                                         multiplier:1.0
+                                                           constant:0.0];
+  top.priority = UILayoutPriorityDefaultHigh;
+  [self.scrollView addConstraint:top];
+  
+  // Height at least as much as the scroll view
+  NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:self.scrollContentView
+                                                             attribute:NSLayoutAttributeHeight
+                                                             relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                                toItem:self.scrollView
+                                                             attribute:NSLayoutAttributeHeight
+                                                            multiplier:1.0
+                                                              constant:0.0];
+  [self.scrollView addConstraint:height];
+  
+  // Expand to be as tall as the modal
+  NSLayoutConstraint * modalForcedHeight = [NSLayoutConstraint constraintWithItem:self.scrollContentView
+                                                                        attribute:NSLayoutAttributeHeight
+                                                                        relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                                           toItem:self.modalView
+                                                                        attribute:NSLayoutAttributeHeight
+                                                                       multiplier:1.0
+                                                                         constant:0.0];
+  [self.scrollView addConstraint:modalForcedHeight];
+}
+
 - (void)setupModalConstraints {
   NSLayoutConstraint *constW = [NSLayoutConstraint constraintWithItem:self.modalView
                                                             attribute:NSLayoutAttributeWidth
@@ -250,26 +302,16 @@
   NSLayoutConstraint *constB = [NSLayoutConstraint constraintWithItem:self.modalView
                                                             attribute:NSLayoutAttributeBottom
                                                             relatedBy:NSLayoutRelationEqual
-                                                               toItem:self.scrollView
+                                                               toItem:[self.scrollContentView layoutAreaItemForConstraints]
                                                             attribute:NSLayoutAttributeBottom
                                                            multiplier:1
                                                              constant:0];
-  [self.scrollView addConstraint:constB];
-
-  self.constraintTopToModalTop = [NSLayoutConstraint constraintWithItem:self.modalView
-                                                              attribute:NSLayoutAttributeTop
-                                                              relatedBy:NSLayoutRelationEqual
-                                                                 toItem:self.scrollView
-                                                              attribute:NSLayoutAttributeTop
-                                                             multiplier:1
-                                                               constant:self.view.frame.size.height + 32];
-
-  [self.scrollView addConstraint:self.constraintTopToModalTop];
+  [self.scrollContentView addConstraint:constB];
 
   NSLayoutConstraint *constL = [NSLayoutConstraint constraintWithItem:self.modalView
                                                             attribute:NSLayoutAttributeLeft
                                                             relatedBy:NSLayoutRelationEqual
-                                                               toItem:self.scrollView
+                                                               toItem:self.scrollContentView
                                                             attribute:NSLayoutAttributeLeft
                                                            multiplier:1
                                                              constant:0];
@@ -278,7 +320,7 @@
   NSLayoutConstraint *constR = [NSLayoutConstraint constraintWithItem:self.modalView
                                                             attribute:NSLayoutAttributeRight
                                                             relatedBy:NSLayoutRelationEqual
-                                                               toItem:self.scrollView
+                                                               toItem:self.scrollContentView
                                                             attribute:NSLayoutAttributeRight
                                                            multiplier:1
                                                              constant:0];

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
@@ -31,6 +31,7 @@
 - (void)setupViews {
   [self setupModalView];
   [self setupScrollView];
+  [self setupScrollContentView];
   [self setupQuestionView];
   [self setupFeedbackView];
   [self setupSocialShareView];
@@ -41,7 +42,8 @@
 
   [self addViewsToModal];
   [self.view addSubview:self.scrollView];
-  [self.scrollView addSubview:self.modalView];
+  [self.scrollView addSubview:self.scrollContentView];
+  [self.scrollContentView addSubview:self.modalView];
 }
 
 #pragma mark - Buttons
@@ -104,6 +106,11 @@
 }
 
 #pragma mark - Modals
+
+- (void)setupScrollContentView {
+  self.scrollContentView = [[UIView alloc] init];
+  self.scrollContentView.translatesAutoresizingMaskIntoConstraints = NO;
+}
 
 - (void)setupModalView {
   self.modalView = [[WTRModalView alloc] init];

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
@@ -69,7 +69,10 @@
   self.finalThankYouLabel.lineBreakMode = NSLineBreakByWordWrapping;
   self.finalThankYouLabel.hidden = YES;
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     self.finalThankYouLabel.font = [UIFont systemFontOfSize:18 weight:UIFontWeightMedium];
+#pragma clang diagnostic pop
   } else {
     self.finalThankYouLabel.font = [UIFont systemFontOfSize:18];
   }

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.h
@@ -34,13 +34,13 @@
 @interface WTRSurveyViewController : UIViewController <UITextViewDelegate>
 
 @property (nonatomic, strong) WTRModalView *modalView;
+@property (nonatomic, strong) UIView * scrollContentView;
 @property (nonatomic, strong) WTRFeedbackView *feedbackView;
 @property (nonatomic, strong) WTRQuestionView *questionView;
 @property (nonatomic, strong) WTRSocialShareView *socialShareView;
 @property (nonatomic, strong) UIButton *sendButton;
 @property (nonatomic, strong) UIButton *poweredByWootric;
 @property (nonatomic, strong) UIScrollView *scrollView;
-@property (nonatomic, strong) NSLayoutConstraint *constraintTopToModalTop;
 @property (nonatomic, strong) NSLayoutConstraint *socialShareViewHeightConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *constraintModalHeight;
 @property (nonatomic, strong) WTRSettings *settings;

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -339,21 +339,24 @@
 
 - (void)registerForKeyboardNotification {
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillShow:")
-                                               name:UIKeyboardWillShowNotification
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillHide:")
-                                               name:UIKeyboardWillHideNotification
-                                             object:nil];
+                                            selector:@selector(keyboardFrameChanging:)
+                                                name:UIKeyboardWillChangeFrameNotification
+                                              object:nil];
 }
 
-- (void)keyboardWillShow:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:YES notification:notification];
-}
-
-- (void)keyboardWillHide:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:NO notification:notification];
+- (void)keyboardFrameChanging:(NSNotification *)notification {
+  CGRect keyboardFrameInWindow = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  CGRect scrollViewFrameInWindow = [_scrollView convertRect:_scrollView.bounds toView:nil];
+  CGRect overlap = CGRectIntersection(keyboardFrameInWindow, scrollViewFrameInWindow);
+  NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] floatValue];
+  UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
+  CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
+  
+  [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
+    self->_scrollView.contentInset = insets;
+    self->_scrollView.scrollIndicatorInsets = insets;
+    self->_scrollView.contentOffset = contentOffset;
+  } completion:nil];
 }
 
 - (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -66,17 +66,20 @@
 }
 
 - (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+  
   [UIView animateWithDuration:0.25 animations:^{
     self.view.backgroundColor = [WTRColor viewBackgroundColor];
-    CGRect modalFrame = _modalView.frame;
-    CGFloat modalPosition = self.view.frame.size.height - _modalView.frame.size.height;
-    modalFrame.origin.y = modalPosition;
-    _modalView.frame = modalFrame;
-    _constraintTopToModalTop.constant = modalPosition;
   }];
-  [self setModalGradient:_modalView.bounds];
+  
+  [self setModalGradient:self.view.bounds];
   [_modalView.layer insertSublayer:_gradient atIndex:0];
   [_questionView addDotsAndScores];
+}
+
+- (void) viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  [self setModalGradient:self.view.bounds];
 }
 
 #pragma mark - Button methods
@@ -228,7 +231,6 @@
   if (!twitterAvailable && !facebookAvailable) {
     _constraintModalHeight.constant = 230;
     _socialShareViewHeightConstraint.constant = 190;
-    _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
     [UIView animateWithDuration:0.2 animations:^{
       [self.view layoutIfNeeded];
     }];
@@ -264,7 +266,6 @@
   _finalThankYouLabel.hidden = NO;
   [_modalView hideDismissButton];
   _constraintModalHeight.constant = 125;
-  _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
   [UIView animateWithDuration:0.2 animations:^{
     [self.view layoutIfNeeded];
   }];
@@ -284,41 +285,6 @@
 - (void)setModalGradient:(CGRect)bounds {
   _gradient.frame = bounds;
   _gradient.colors = @[(id)[WTRColor grayGradientTopColor].CGColor, (id)[WTRColor grayGradientBottomColor].CGColor];
-}
-
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-  [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-
-  BOOL isToLandscape = UIInterfaceOrientationIsLandscape(toInterfaceOrientation);
-  CGFloat modalPosition;
-  CGRect bounds = self.view.bounds;
-  CGRect gradientBounds;
-
-  if ((bounds.size.width > bounds.size.height) && isToLandscape) {
-    modalPosition = bounds.size.height - _modalView.frame.size.height;
-  } else {
-    modalPosition = bounds.size.width - _modalView.frame.size.height;
-  }
-
-  if ((bounds.size.height > bounds.size.width) && isToLandscape) {
-    gradientBounds = CGRectMake(bounds.origin.y, bounds.origin.x, bounds.size.height, bounds.size.width);
-  } else {
-    gradientBounds = bounds;
-  }
-
-  _constraintTopToModalTop.constant = modalPosition;
-  [self setModalGradient:gradientBounds];
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
-  [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-  _scrolled = NO;
-
-  BOOL isFromLandscape = UIInterfaceOrientationIsLandscape(fromInterfaceOrientation);
-  CGRect bounds = self.view.bounds;
-  if (_keyboardHeight == 0 && isFromLandscape && (bounds.size.width > bounds.size.height)) {
-    [_scrollView scrollRectToVisible:_modalView.frame animated:YES];
-  }
 }
 
 - (void)registerForKeyboardNotification {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -34,7 +34,6 @@
 
 @interface WTRSurveyViewController ()
 
-@property (nonatomic, assign) BOOL scrolled;
 @property (nonatomic, assign) BOOL alreadyVoted;
 @property (nonatomic, assign) CGFloat keyboardHeight;
 @property (nonatomic, strong) CAGradientLayer *gradient;
@@ -92,7 +91,6 @@
 
 - (void)editScoreButtonPressed:(UIButton *)sender {
   [_feedbackView textViewResignFirstResponder];
-  _scrolled = NO;
   [self setQuestionViewVisible:YES andFeedbackViewVisible:NO];
 }
 
@@ -328,7 +326,6 @@
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
   [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-  _scrolled = NO;
 
   BOOL isFromLandscape = UIInterfaceOrientationIsLandscape(fromInterfaceOrientation);
   CGRect bounds = self.view.bounds;
@@ -357,23 +354,6 @@
     self->_scrollView.scrollIndicatorInsets = insets;
     self->_scrollView.contentOffset = contentOffset;
   } completion:nil];
-}
-
-- (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {
-  NSDictionary *userInfo = notification.userInfo ? notification.userInfo : @{};
-  CGRect keyboardFrame = [userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  double adjustmentHeight = CGRectGetHeight(keyboardFrame) * (show ? 1 : -1);
-  UIEdgeInsets contentInsets = UIEdgeInsetsMake(0, 0, adjustmentHeight, 0);
-  _scrollView.contentInset = contentInsets;
-  _scrollView.scrollIndicatorInsets = contentInsets;
-
-  if ((_keyboardHeight != keyboardFrame.size.height)) {
-    _keyboardHeight = keyboardFrame.size.height;
-    [_scrollView setContentOffset:CGPointMake(0, _keyboardHeight) animated:YES];
-  } else if (!_scrolled) {
-    [_scrollView scrollRectToVisible:_modalView.frame animated:YES];
-    _scrolled = YES;
-  }
 }
 
 - (void)textViewDidChange:(UITextView *)textView {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -286,21 +286,6 @@
   _gradient.colors = @[(id)[WTRColor grayGradientTopColor].CGColor, (id)[WTRColor grayGradientBottomColor].CGColor];
 }
 
-- (void)getSizeAndRecalculatePositionsBasedOnOrientation:(UIInterfaceOrientation)interfaceOrientation {
-  BOOL isFromLandscape = UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]);
-  BOOL isToLandscape = UIInterfaceOrientationIsLandscape(interfaceOrientation);
-  if ((!isFromLandscape && isToLandscape) || (isFromLandscape && !isToLandscape)) {
-    CGFloat widthAfterRotation;
-    CGFloat leftAndRightMargins = 28;
-    if (IS_OS_8_OR_LATER || isToLandscape) {
-      widthAfterRotation = self.view.frame.size.height - leftAndRightMargins;
-    } else {
-      widthAfterRotation = self.view.frame.size.width - leftAndRightMargins;
-    }
-    [_questionView recalculateDotsAndScorePositionForWidth:widthAfterRotation];
-  }
-}
-
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
   [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 
@@ -322,7 +307,6 @@
   }
 
   _constraintTopToModalTop.constant = modalPosition;
-  [self getSizeAndRecalculatePositionsBasedOnOrientation:toInterfaceOrientation];
   [self setModalGradient:gradientBounds];
 }
 

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -349,6 +349,20 @@
   UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
   CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
   
+  // If the text view is off screen, fix that
+  if ([_feedbackView isActive]) {
+    CGRect firstResponderFrame = [_feedbackView frameForFirstResponder];
+    
+    if (!CGRectIsEmpty(firstResponderFrame)) {
+      // We have a first responder within the feedback view.  Is it off screen?
+      CGRect firstResponderFrameInScrollView = [_scrollView convertRect:firstResponderFrame fromView:_feedbackView];
+      
+      if (contentOffset.y > firstResponderFrameInScrollView.origin.y) {
+        contentOffset.y = firstResponderFrameInScrollView.origin.y;
+      }
+    }
+  }
+  
   [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
     self->_scrollView.contentInset = insets;
     self->_scrollView.scrollIndicatorInsets = insets;

--- a/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
@@ -133,29 +133,29 @@
 
 - (void)setupSendButtonConstraints {
   [_sendButton wtr_constraintWidth:100];
-  [[[[_sendButton wtr_topConstraint] toSecondViewBottom:_followupLabel] withConstant:8] addToView:self];
-  [[[_sendButton wtr_bottomConstraint] toSecondViewBottom:self] addToView:self];
-  [[[_sendButton wtr_leftConstraint] toSecondViewRight:_feedbackTextView] addToView:self];
+  [[[[_sendButton wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:8] addToView:self];
+  [[[_sendButton wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
+  [[[_sendButton wtr_leftConstraint] toSecondItemRight:_feedbackTextView] addToView:self];
 }
 
 - (void)setupFollowupLabelConstraints {
-  [[[_followupLabel wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_followupLabel wtr_topConstraint] toSecondViewTop:self] withConstant:20] addToView:self];
-  [[[[_followupLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:16] addToView:self];
-  [[[[_followupLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-16] addToView:self];
+  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:self] withConstant:20] addToView:self];
+  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
+  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
 }
 
 - (void)setupFeedbackTextViewConstraints {
-  [[[[_feedbackTextView wtr_leftConstraint] toSecondViewLeft:self] withConstant:16] addToView:self];
-  [[[[_feedbackTextView wtr_rightConstraint] toSecondViewRight:self] withConstant:-116] addToView:self];
-  [[[[_feedbackTextView wtr_topConstraint] toSecondViewBottom:_followupLabel] withConstant:8] addToView:self];
-  [[[_feedbackTextView wtr_bottomConstraint] toSecondViewBottom:self] addToView:self];
+  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
+  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:self] withConstant:-116] addToView:self];
+  [[[[_feedbackTextView wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:8] addToView:self];
+  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
 }
 
 - (void)setupFeedbackLabelConstraints {
-  [[[[_feedbackPlaceholder wtr_leftConstraint] toSecondViewLeft:_feedbackTextView] withConstant:20] addToView:self];
-  [[[[_feedbackPlaceholder wtr_rightConstraint] toSecondViewRight:_feedbackTextView] withConstant:-20] addToView:self];
-  [[[[_feedbackPlaceholder wtr_topConstraint] toSecondViewTop:_feedbackTextView] withConstant:17] addToView:self];
+  [[[[_feedbackPlaceholder wtr_leftConstraint] toSecondItemLeft:_feedbackTextView] withConstant:20] addToView:self];
+  [[[[_feedbackPlaceholder wtr_rightConstraint] toSecondItemRight:_feedbackTextView] withConstant:-20] addToView:self];
+  [[[[_feedbackPlaceholder wtr_topConstraint] toSecondItemTop:_feedbackTextView] withConstant:17] addToView:self];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
@@ -27,6 +27,7 @@
 #import "WTRSurveyViewController.h"
 #import "SimpleConstraints.h"
 #import "UIItems.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRiPADFeedbackView ()
 
@@ -134,22 +135,24 @@
 - (void)setupSendButtonConstraints {
   [_sendButton wtr_constraintWidth:100];
   [[[[_sendButton wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:8] addToView:self];
-  [[[_sendButton wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
+  [[[_sendButton wtr_bottomConstraint] toSecondItemBottom:[self layoutAreaItemForConstraints]] addToView:self];
   [[[_sendButton wtr_leftConstraint] toSecondItemRight:_feedbackTextView] addToView:self];
 }
 
 - (void)setupFollowupLabelConstraints {
-  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
-  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:self] withConstant:20] addToView:self];
-  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
-  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-16] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[_followupLabel wtr_centerXConstraint] toSecondItemCenterX:layoutArea] addToView:self];
+  [[[[_followupLabel wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:20] addToView:self];
+  [[[[_followupLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:16] addToView:self];
+  [[[[_followupLabel wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-16] addToView:self];
 }
 
 - (void)setupFeedbackTextViewConstraints {
-  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:self] withConstant:16] addToView:self];
-  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:self] withConstant:-116] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_feedbackTextView wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:16] addToView:self];
+  [[[[_feedbackTextView wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-116] addToView:self];
   [[[[_feedbackTextView wtr_topConstraint] toSecondItemBottom:_followupLabel] withConstant:8] addToView:self];
-  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:self] addToView:self];
+  [[[_feedbackTextView wtr_bottomConstraint] toSecondItemBottom:layoutArea] addToView:self];
 }
 
 - (void)setupFeedbackLabelConstraints {

--- a/WootricSDK/WootricSDK/WTRiPADQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRiPADQuestionView.m
@@ -27,6 +27,7 @@
 #import "WTRColor.h"
 #import "SimpleConstraints.h"
 #import "UIItems.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRiPADQuestionView ()
 
@@ -112,13 +113,14 @@
 }
 
 - (void)setupQuestionLabelConstraints {
-  [[[[_questionLabel wtr_topConstraint] toSecondItemTop:self] withConstant:20] addToView:self];
-  [[[[_questionLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:45] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_questionLabel wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:20] addToView:self];
+  [[[[_questionLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:45] addToView:self];
   [[[[self wtr_rightConstraint] toSecondItemRight:_questionLabel] withConstant:45] addToView:self];
 }
 
 - (void)setupScoreViewConstraints {
-  [[[_scoreView wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[_scoreView wtr_centerXConstraint] toSecondItemCenterX:[self layoutAreaItemForConstraints]] addToView:self];
   [[[[_scoreView wtr_topConstraint] toSecondItemBottom:_questionLabel] withConstant:20] addToView:self];
 }
 

--- a/WootricSDK/WootricSDK/WTRiPADQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRiPADQuestionView.m
@@ -92,8 +92,8 @@
       rightConstraint = 10;
     }
   }
-  [[[_likelyAnchor wtr_centerYConstraint] toSecondViewCenterY:_scoreView] addToView:self];
-  [[[[_likelyAnchor wtr_leftConstraint] toSecondViewRight:_scoreView] withConstant:rightConstraint] addToView:self];
+  [[[_likelyAnchor wtr_centerYConstraint] toSecondItemCenterY:_scoreView] addToView:self];
+  [[[[_likelyAnchor wtr_leftConstraint] toSecondItemRight:_scoreView] withConstant:rightConstraint] addToView:self];
 }
 
 - (void)setupNotLikelyAnchorConstraints {
@@ -107,19 +107,19 @@
       leftConstraint = -10;
     }
   }
-  [[[_notLikelyAnchor wtr_centerYConstraint] toSecondViewCenterY:_scoreView] addToView:self];
-  [[[[_notLikelyAnchor wtr_rightConstraint] toSecondViewLeft:_scoreView] withConstant:leftConstraint] addToView:self];
+  [[[_notLikelyAnchor wtr_centerYConstraint] toSecondItemCenterY:_scoreView] addToView:self];
+  [[[[_notLikelyAnchor wtr_rightConstraint] toSecondItemLeft:_scoreView] withConstant:leftConstraint] addToView:self];
 }
 
 - (void)setupQuestionLabelConstraints {
-  [[[[_questionLabel wtr_topConstraint] toSecondViewTop:self] withConstant:20] addToView:self];
-  [[[[_questionLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:45] addToView:self];
-  [[[[self wtr_rightConstraint] toSecondViewRight:_questionLabel] withConstant:45] addToView:self];
+  [[[[_questionLabel wtr_topConstraint] toSecondItemTop:self] withConstant:20] addToView:self];
+  [[[[_questionLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:45] addToView:self];
+  [[[[self wtr_rightConstraint] toSecondItemRight:_questionLabel] withConstant:45] addToView:self];
 }
 
 - (void)setupScoreViewConstraints {
-  [[[_scoreView wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
-  [[[[_scoreView wtr_topConstraint] toSecondViewBottom:_questionLabel] withConstant:20] addToView:self];
+  [[[_scoreView wtr_centerXConstraint] toSecondItemCenterX:self] addToView:self];
+  [[[[_scoreView wtr_topConstraint] toSecondItemBottom:_questionLabel] withConstant:20] addToView:self];
 }
 
 - (void)setupCircleScoreViewWithViewController:(UIViewController *)viewController {

--- a/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
@@ -28,6 +28,7 @@
 #import "NSString+FontAwesome.h"
 #import "WTRiPADThankYouButton.h"
 #import "SimpleConstraints.h"
+#import "UIView+SafeArea.h"
 
 @interface WTRiPADSocialShareView ()
 
@@ -210,25 +211,28 @@
 #pragma mark - Setup Constraints
 
 - (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:layoutArea] withConstant:16] addToView:self];
+  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
   [[[[self wtr_rightConstraint] toSecondItemRight:_finalThankYouLabel] withConstant:24] addToView:self];
 }
 
 - (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  id layoutArea = [self layoutAreaItemForConstraints];
+  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:layoutArea] withConstant:24] addToView:self];
+  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:layoutArea] withConstant:-24] addToView:self];
   [[[[_customThankYouLabel wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:12] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_thankYouButton wtr_constraintHeight:40];
-  [[[[_thankYouButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-44] addToView:self];
+  [[[[_thankYouButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-44] addToView:self];
 
   _thankYouXConstraint = [NSLayoutConstraint constraintWithItem:_thankYouButton
                                                       attribute:NSLayoutAttributeCenterX
                                                       relatedBy:NSLayoutRelationEqual
-                                                         toItem:self
+                                                         toItem:layoutArea
                                                       attribute:NSLayoutAttributeCenterX
                                                      multiplier:1
                                                        constant:0];
@@ -236,13 +240,14 @@
 }
 
 - (void)setupNoThanksButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_noThanksButton wtr_constraintHeight:40];
-  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-44] addToView:self];
+  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-44] addToView:self];
 
   _noThanksXConstraint = [NSLayoutConstraint constraintWithItem:_noThanksButton
                                                       attribute:NSLayoutAttributeCenterX
                                                       relatedBy:NSLayoutRelationEqual
-                                                         toItem:self
+                                                         toItem:layoutArea
                                                       attribute:NSLayoutAttributeCenterX
                                                      multiplier:1
                                                        constant:0];
@@ -250,14 +255,15 @@
 }
 
 - (void)setupFacebookButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_facebookButton wtr_constraintWidth:32];
   [_facebookButton wtr_constraintHeight:32];
-  [[[[_facebookButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
+  [[[[_facebookButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-48] addToView:self];
 
   _facebookXConstraint = [NSLayoutConstraint constraintWithItem:_facebookButton
                                                       attribute:NSLayoutAttributeCenterX
                                                       relatedBy:NSLayoutRelationEqual
-                                                         toItem:self
+                                                         toItem:layoutArea
                                                       attribute:NSLayoutAttributeCenterX
                                                      multiplier:1
                                                        constant:0];
@@ -265,14 +271,15 @@
 }
 
 - (void)setupTwitterButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_twitterButton wtr_constraintWidth:32];
   [_twitterButton wtr_constraintHeight:32];
-  [[[[_twitterButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
+  [[[[_twitterButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-48] addToView:self];
 
   _twitterXConstraint = [NSLayoutConstraint constraintWithItem:_twitterButton
                                                      attribute:NSLayoutAttributeCenterX
                                                      relatedBy:NSLayoutRelationEqual
-                                                        toItem:self
+                                                        toItem:layoutArea
                                                      attribute:NSLayoutAttributeCenterX
                                                     multiplier:1
                                                       constant:0];
@@ -280,14 +287,15 @@
 }
 
 - (void)setupFacebookLikeButtonConstraints {
+  id layoutArea = [self layoutAreaItemForConstraints];
   [_facebookLikeButton wtr_constraintWidth:32];
   [_facebookLikeButton wtr_constraintHeight:32];
-  [[[[_facebookLikeButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
+  [[[[_facebookLikeButton wtr_bottomConstraint] toSecondItemBottom:layoutArea] withConstant:-48] addToView:self];
     
   _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
                                                           attribute:NSLayoutAttributeCenterX
                                                           relatedBy:NSLayoutRelationEqual
-                                                             toItem:self
+                                                             toItem:layoutArea
                                                           attribute:NSLayoutAttributeCenterX
                                                          multiplier:1
                                                            constant:0];

--- a/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
@@ -210,20 +210,20 @@
 #pragma mark - Setup Constraints
 
 - (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[self wtr_rightConstraint] toSecondViewRight:_finalThankYouLabel] withConstant:24] addToView:self];
+  [[[[_finalThankYouLabel wtr_topConstraint] toSecondItemTop:self] withConstant:16] addToView:self];
+  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[self wtr_rightConstraint] toSecondItemRight:_finalThankYouLabel] withConstant:24] addToView:self];
 }
 
 - (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_customThankYouLabel wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:12] addToView:self];
+  [[[[_customThankYouLabel wtr_leftConstraint] toSecondItemLeft:self] withConstant:24] addToView:self];
+  [[[[_customThankYouLabel wtr_rightConstraint] toSecondItemRight:self] withConstant:-24] addToView:self];
+  [[[[_customThankYouLabel wtr_topConstraint] toSecondItemBottom:_finalThankYouLabel] withConstant:12] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {
   [_thankYouButton wtr_constraintHeight:40];
-  [[[[_thankYouButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-44] addToView:self];
+  [[[[_thankYouButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-44] addToView:self];
 
   _thankYouXConstraint = [NSLayoutConstraint constraintWithItem:_thankYouButton
                                                       attribute:NSLayoutAttributeCenterX
@@ -237,7 +237,7 @@
 
 - (void)setupNoThanksButtonConstraints {
   [_noThanksButton wtr_constraintHeight:40];
-  [[[[_noThanksButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-44] addToView:self];
+  [[[[_noThanksButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-44] addToView:self];
 
   _noThanksXConstraint = [NSLayoutConstraint constraintWithItem:_noThanksButton
                                                       attribute:NSLayoutAttributeCenterX
@@ -252,7 +252,7 @@
 - (void)setupFacebookButtonConstraints {
   [_facebookButton wtr_constraintWidth:32];
   [_facebookButton wtr_constraintHeight:32];
-  [[[[_facebookButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-48] addToView:self];
+  [[[[_facebookButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
 
   _facebookXConstraint = [NSLayoutConstraint constraintWithItem:_facebookButton
                                                       attribute:NSLayoutAttributeCenterX
@@ -267,7 +267,7 @@
 - (void)setupTwitterButtonConstraints {
   [_twitterButton wtr_constraintWidth:32];
   [_twitterButton wtr_constraintHeight:32];
-  [[[[_twitterButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-48] addToView:self];
+  [[[[_twitterButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
 
   _twitterXConstraint = [NSLayoutConstraint constraintWithItem:_twitterButton
                                                      attribute:NSLayoutAttributeCenterX
@@ -282,7 +282,7 @@
 - (void)setupFacebookLikeButtonConstraints {
   [_facebookLikeButton wtr_constraintWidth:32];
   [_facebookLikeButton wtr_constraintHeight:32];
-  [[[[_facebookLikeButton wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-48] addToView:self];
+  [[[[_facebookLikeButton wtr_bottomConstraint] toSecondItemBottom:self] withConstant:-48] addToView:self];
     
   _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
                                                           attribute:NSLayoutAttributeCenterX

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
@@ -43,15 +43,15 @@
 
 - (void)setupPoweredByWootricConstraints {
   [self.poweredByWootric wtr_constraintHeight:12];
-  [[[self.poweredByWootric wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
-  [[[[self.poweredByWootric wtr_bottomConstraint] toSecondViewBottom:self.modalView] withConstant:-14] addToView:self.modalView];
+  [[[self.poweredByWootric wtr_centerXConstraint] toSecondItemCenterX:self.modalView] addToView:self.modalView];
+  [[[[self.poweredByWootric wtr_bottomConstraint] toSecondItemBottom:self.modalView] withConstant:-14] addToView:self.modalView];
 }
 
 - (void)setupScrollViewConstraints {
   [self.scrollView wtr_constraintWidthEqualSecondViewWidth:self.view];
   [self.scrollView wtr_constraintHeightEqualSecondViewHeight:self.view];
-  [[[self.scrollView wtr_centerXConstraint] toSecondViewCenterX:self.view] addConstraint];
-  [[[self.scrollView wtr_centerYConstraint] toSecondViewCenterY:self.view] addConstraint];
+  [[[self.scrollView wtr_centerXConstraint] toSecondItemCenterX:self.view] addConstraint];
+  [[[self.scrollView wtr_centerYConstraint] toSecondItemCenterY:self.view] addConstraint];
 }
 
 - (void)setupModalConstraints {
@@ -76,31 +76,31 @@
   [self.scrollView addConstraint:self.constraintTopToModalTop];
 
   [self.modalView wtr_constraintWidthEqualSecondViewWidth:self.view];
-  [[[self.modalView wtr_centerXConstraint] toSecondViewCenterX:self.view] addToView:self.view];
-  [[[self.modalView wtr_bottomConstraint] toSecondViewBottom:self.scrollView] addToView:self.scrollView];
-  [[[self.modalView wtr_leftConstraint] toSecondViewLeft:self.scrollView] addToView:self.scrollView];
-  [[[self.modalView wtr_rightConstraint] toSecondViewRight:self.scrollView] addToView:self.scrollView];
+  [[[self.modalView wtr_centerXConstraint] toSecondItemCenterX:self.view] addToView:self.view];
+  [[[self.modalView wtr_bottomConstraint] toSecondItemBottom:self.scrollView] addToView:self.scrollView];
+  [[[self.modalView wtr_leftConstraint] toSecondItemLeft:self.scrollView] addToView:self.scrollView];
+  [[[self.modalView wtr_rightConstraint] toSecondItemRight:self.scrollView] addToView:self.scrollView];
 }
 
 - (void)setupQuestionViewConstraints {
   [self.questionView wtr_constraintWidthEqualSecondViewWidth:self.view];
   [self.questionView wtr_constraintHeight:110];
-  [[[self.questionView wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
-  self.constraintQuestionTopToModalTop = [[self.questionView wtr_topConstraint] toSecondViewTop:self.modalView];
+  [[[self.questionView wtr_centerXConstraint] toSecondItemCenterX:self.modalView] addToView:self.modalView];
+  self.constraintQuestionTopToModalTop = [[self.questionView wtr_topConstraint] toSecondItemTop:self.modalView];
   [self.constraintQuestionTopToModalTop addToView:self.modalView];
 }
 
 - (void)setupFeedbackViewConstraints {
   [self.feedbackView wtr_constraintHeight:100];
   [self.feedbackView wtr_constraintWidthToSecondViewWidth:self.view withConstant:-80];
-  [[[self.feedbackView wtr_topConstraint] toSecondViewTop:self.modalView] addToView:self.modalView];
-  [[[self.feedbackView wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
+  [[[self.feedbackView wtr_topConstraint] toSecondItemTop:self.modalView] addToView:self.modalView];
+  [[[self.feedbackView wtr_centerXConstraint] toSecondItemCenterX:self.modalView] addToView:self.modalView];
 }
 
 - (void)setupSocialShareViewConstraints {
   [self.socialShareView wtr_constraintWidthEqualSecondViewWidth:self.view];
-  [[[self.socialShareView wtr_topConstraint] toSecondViewTop:self.modalView] addToView:self.modalView];
-  [[[self.socialShareView wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
+  [[[self.socialShareView wtr_topConstraint] toSecondItemTop:self.modalView] addToView:self.modalView];
+  [[[self.socialShareView wtr_centerXConstraint] toSecondItemCenterX:self.modalView] addToView:self.modalView];
 
   self.socialShareViewHeightConstraint = [NSLayoutConstraint constraintWithItem:self.socialShareView
                                                                       attribute:NSLayoutAttributeHeight
@@ -114,16 +114,16 @@
 }
 
 - (void)setupFinalThankYouLabelConstraints {
-  [[[[self.finalThankYouLabel wtr_topConstraint] toSecondViewTop:self.modalView] withConstant:36] addToView:self.modalView];
-  [[[[self.finalThankYouLabel wtr_leftConstraint] toSecondViewLeft:self.modalView] withConstant:24] addToView:self.modalView];
-  [[[[self.finalThankYouLabel wtr_rightConstraint] toSecondViewRight:self.modalView] withConstant:-24] addToView:self.modalView];
+  [[[[self.finalThankYouLabel wtr_topConstraint] toSecondItemTop:self.modalView] withConstant:36] addToView:self.modalView];
+  [[[[self.finalThankYouLabel wtr_leftConstraint] toSecondItemLeft:self.modalView] withConstant:24] addToView:self.modalView];
+  [[[[self.finalThankYouLabel wtr_rightConstraint] toSecondItemRight:self.modalView] withConstant:-24] addToView:self.modalView];
 }
 
 - (void)setupDismissButtonConstraints {
   [self.dismissButton wtr_constraintHeight:30];
   [self.dismissButton wtr_constraintWidth:30];
-  [[[[self.dismissButton wtr_topConstraint] toSecondViewTop:self.modalView] withConstant:8] addToView:self.view];
-  [[[[self.dismissButton wtr_rightConstraint] toSecondViewRight:self.modalView] withConstant:-8] addToView:self.view];
+  [[[[self.dismissButton wtr_topConstraint] toSecondItemTop:self.modalView] withConstant:8] addToView:self.view];
+  [[[[self.dismissButton wtr_rightConstraint] toSecondItemRight:self.modalView] withConstant:-8] addToView:self.view];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.m
@@ -30,6 +30,7 @@
 - (void)setupViews {
   [self setupModalView];
   [self setupScrollView];
+  [self setupScrollContentView];
   [self setupQuestionView];
   [self setupFeedbackView];
   [self setupSocialShareView];
@@ -39,7 +40,8 @@
 
   [self addViewsToModal];
   [self.view addSubview:self.scrollView];
-  [self.scrollView addSubview:self.modalView];
+  [self.scrollView addSubview:self.scrollContentView];
+  [self.scrollContentView addSubview:self.modalView];
 }
 
 - (void)addViewsToModal {
@@ -105,6 +107,11 @@
 
 - (void)setupModalView {
   self.modalView = [[WTRiPADModalView alloc] init];
+}
+
+- (void)setupScrollContentView {
+  self.scrollContentView = [[UIView alloc] init];
+  self.scrollContentView.translatesAutoresizingMaskIntoConstraints = NO;
 }
 
 - (void)setupScrollView {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
@@ -33,13 +33,13 @@
 
 @property (nonatomic, strong) WTRSettings *settings;
 @property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, strong) UIView * scrollContentView;
 @property (nonatomic, strong) UIButton *poweredByWootric;
 @property (nonatomic, strong) UIButton *dismissButton;
 @property (nonatomic, strong) WTRiPADModalView *modalView;
 @property (nonatomic, strong) WTRiPADQuestionView *questionView;
 @property (nonatomic, strong) WTRiPADFeedbackView *feedbackView;
 @property (nonatomic, strong) WTRiPADSocialShareView *socialShareView;
-@property (nonatomic, strong) NSLayoutConstraint *constraintTopToModalTop;
 @property (nonatomic, strong) NSLayoutConstraint *constraintQuestionTopToModalTop;
 @property (nonatomic, strong) NSLayoutConstraint *constraintModalHeight;
 @property (nonatomic, strong) NSLayoutConstraint *socialShareViewHeightConstraint;

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -34,7 +34,6 @@
 
 @interface WTRiPADSurveyViewController ()
 
-@property (nonatomic, assign) BOOL scrolled;
 @property (nonatomic, assign) int currentScore;
 @property (nonatomic, assign) BOOL alreadyVoted;
 @property (nonatomic, assign) CGFloat keyboardHeight;

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -296,21 +296,24 @@
 
 - (void)registerForKeyboardNotification {
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillShow:")
-                                               name:UIKeyboardWillShowNotification
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:NSSelectorFromString(@"keyboardWillHide:")
-                                               name:UIKeyboardWillHideNotification
+                                           selector:@selector(keyboardFrameChanging:)
+                                               name:UIKeyboardWillChangeFrameNotification
                                              object:nil];
 }
 
-- (void)keyboardWillShow:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:YES notification:notification];
-}
-
-- (void)keyboardWillHide:(NSNotification *)notification {
-  [self adjustInsetForKeyboardShow:NO notification:notification];
+- (void)keyboardFrameChanging:(NSNotification *)notification {
+  CGRect keyboardFrameInWindow = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  CGRect scrollViewFrameInWindow = [_scrollView convertRect:_scrollView.bounds toView:nil];
+  CGRect overlap = CGRectIntersection(keyboardFrameInWindow, scrollViewFrameInWindow);
+  NSTimeInterval animationDuration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] floatValue];
+  UIEdgeInsets insets = CGRectIsEmpty(overlap) ? UIEdgeInsetsZero : UIEdgeInsetsMake(0.0, 0.0, overlap.size.height, 0.0);
+  CGPoint contentOffset = CGPointMake(0.0, insets.bottom);
+  
+  [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
+    self->_scrollView.contentInset = insets;
+    self->_scrollView.scrollIndicatorInsets = insets;
+    self->_scrollView.contentOffset = contentOffset;
+  } completion:nil];
 }
 
 - (void)adjustInsetForKeyboardShow:(BOOL)show notification:(NSNotification *)notification {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -71,7 +71,6 @@
     CGFloat modalPosition = self.view.frame.size.height - _modalView.frame.size.height;
     modalFrame.origin.y = modalPosition;
     _modalView.frame = modalFrame;
-    _constraintTopToModalTop.constant = modalPosition;
   }];
 }
 
@@ -96,7 +95,6 @@
   _feedbackView.hidden = NO;
   _constraintModalHeight.constant = 215;
   _constraintQuestionTopToModalTop.constant = 50;
-  _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
   [UIView animateWithDuration:0.2 animations:^{
     [self.view layoutIfNeeded];
   } completion:^(BOOL finished) {
@@ -235,7 +233,6 @@
 
 - (void)presentSocialShareViewWithScore:(int)score {
   _constraintModalHeight.constant = 165;
-  _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
   [self setQuestionViewVisible:NO andFeedbackViewVisible:NO];
   [_feedbackView textViewResignFirstResponder];
   _socialShareView.hidden = NO;
@@ -256,7 +253,6 @@
   _finalThankYouLabel.hidden = NO;
   _dismissButton.hidden = YES;
   _constraintModalHeight.constant = 125;
-  _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
   [UIView animateWithDuration:0.2 animations:^{
     [self.view layoutIfNeeded];
   }];
@@ -268,30 +264,6 @@
 - (void)setQuestionViewVisible:(BOOL)questionFlag andFeedbackViewVisible:(BOOL)feedbackFlag {
   _questionView.hidden = !questionFlag;
   _feedbackView.hidden = !feedbackFlag;
-}
-
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-  [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-
-  BOOL isToLandscape = UIInterfaceOrientationIsLandscape(toInterfaceOrientation);
-  CGFloat modalPosition;
-  CGRect bounds = self.view.bounds;
-
-  if ((bounds.size.width > bounds.size.height) && isToLandscape) {
-    modalPosition = bounds.size.height - _modalView.frame.size.height;
-  } else {
-    modalPosition = bounds.size.width - _modalView.frame.size.height;
-  }
-
-  _constraintTopToModalTop.constant = modalPosition;
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
-  [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-
-  if (_keyboardHeight == 0) {
-    [_scrollView setContentOffset:CGPointMake(0, _keyboardHeight) animated:YES];
-  }
 }
 
 - (void)registerForKeyboardNotification {


### PR DESCRIPTION
## The big problem addressed:

iPhone X on landscape:
![landscapebad](https://user-images.githubusercontent.com/1328743/37115238-6d0ba374-21ff-11e8-8fba-8fac2f8751c2.png)

## Smaller problems addressed:

The scrolling as the keyboard is displayed lags a little behind the keyboard itself:
![little gap](https://thumbs.gfycat.com/PolishedUntimelyGhostshrimp-size_restricted.gif)

The feedback view obscures text input when the keyboard appears in iPhone landscape:
![off screen text](https://thumbs.gfycat.com/ReliableCooperativeCavy-size_restricted.gif)

Things get weird if the software keyboard is disabled (most often in the simulator):
![simulator before change](https://thumbs.gfycat.com/NegligibleDizzyArmyworm-size_restricted.gif)

## Warnings fixed/suppressed
- Implementing deprecated methods `willRotateToInterfaceOrientation:duration:` and `didRotateFromInterfaceOrientation:`
- `systemFontOfSize:weight:` is only available on iOS 8.2 or newer

## Summary of changes
These changes rely on auto layout to remove a lot of manual view resizing and positioning and to take the safe area into account.

- Added a category on `UIView` to add `layoutAreaItemForConstraints`.  Any `NSLayoutConstraint` created with a view as an item can instead use `[theView layoutAreaItemForConstraints]` to constrain to the safe area in iOS 11+.
- Modified the `NSLayoutConstraint` convenience methods to accept `id` instead of just `UIView` as layout items.  Allows usage of the above `layoutAreaItemForConstraints`.
- Modified a ton of UI constraints to use the above safe area items instead of views themselves
- Added a container view between the `scrollView` and the `modalView` to allow the modal view to be scooted up into the safe area.
- Replaced the manual layout in `WTRScoreView` and `WTRSlider` with an implementation based on auto layout and invisible spacer views.  This could have been accomplished with `UIStackView`s, but that would require upping iOS support to 9.
- Updated the keyboard avoiding code to use `UIKeyboardWillChangeFrameNotification` and be a bit smarter about timing and positioning
- Removed deprecated `willRotateToInterfaceOrientation:duration:`/`didRotateFromInterfaceOrientation:` implementations.  The gradient setup code was moved to `viewDidLayoutSubviews`.  The rest is now irrelevant with the auto layout additions.
- Surrounded calls to `systemFontOfSize:weight:` with clang warning suppression, since Xcode 9 demands `@available` usage which does not exist in older Xcode versions