### PR TITLE
Add client_id only authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0 (2018-05-03)
+
+### Changes:
+
+- Add new method that just needs client_id & doesn't require the client_secret
+
 ## 0.6.6 (2017-12-15)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.6.6"
+	pod "WootricSDK", "~> 0.7.0"
 	```
 
 3. In your Xcode project directory run the following command:
@@ -61,11 +61,11 @@ WootricSDK task is to present a fully functional survey view with just a few lin
 	#import <WootricSDK/WootricSDK.h>
 	```
 
-2. Configure the SDK with your client ID, secret and account token
+2. Configure the SDK with your client ID and account token
 	```objective-c
-	[Wootric configureWithClientID:<YOUR_CLIENT_ID> clientSecret:<YOUR_CLIENT_SECRET> accountToken:<YOUR_TOKEN>];
+	[Wootric configureWithClientID:<YOUR_CLIENT_ID> accountToken:<YOUR_TOKEN>];
 	``` 
-	*You can find the client ID and client secret on your [Wootric's account settings](https://app.wootric.com/account_settings/edit?) on the API section.*
+	*You can find the client ID on your [Wootric's account settings](https://app.wootric.com/account_settings/edit?) on the API section.*
 
 3. To display the survey (if user is eligible - this check is built in the method) use:
 	```objective-c
@@ -84,7 +84,7 @@ For more information on class methods, please refer to [Wootric's docs](http://c
 
 // Inside your view controller's viewDidLoad method
 
-[Wootric configureWithClientID:YOUR_CLIENT_ID clientSecret:YOUR_CLIENT_SECRET accountToken:YOUR_ACCOUNT_TOKEN];
+[Wootric configureWithClientID:YOUR_CLIENT_ID accountToken:YOUR_ACCOUNT_TOKEN];
 [Wootric setEndUserEmail:@"nps@example.com"];
 [Wootric setEndUserCreatedAt:@1234567890];
 // Use only for testing

--- a/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
+++ b/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
@@ -21,7 +21,7 @@
   NSString *clientSecret = @"YOUR_CLIENT_SECRET";
   NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
   
-  [Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+  [Wootric configureWithClientID:clientID accountToken:accountToken];
   [Wootric setEndUserEmail:@"END_USER_EMAIL"];
   [Wootric setEndUserCreatedAt:@1234567890];
   

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.6.6'
+  s.version  = '0.7.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WootricSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.6</string>
+	<string>0.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -70,7 +70,6 @@
 
 - (BOOL)checkConfiguration {
   if ([_clientID length] != 0 &&
-      [_clientSecret length] != 0 &&
       [_accountToken length] != 0) {
     return YES;
   }
@@ -96,7 +95,6 @@
   
   NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/end_users?email=%@", _baseAPIURL, _apiVersion, escapedEmail]];
   NSMutableURLRequest *urlRequest = [self requestWithURL:url HTTPMethod:nil andHTTPBody:nil];
-  
   NSURLSessionDataTask *dataTask = [_wootricSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
     if (error) {
       NSLog(@"WootricSDK (GET end user): %@", error);
@@ -236,8 +234,12 @@
 - (void)authenticate:(void (^)(void))authenticated {
   
   NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/oauth/token", _baseAPIURL]];
-  NSString *params = [NSString stringWithFormat:@"grant_type=client_credentials&client_id=%@&client_secret=%@", _clientID, _clientSecret];
+  NSString *params = [NSString stringWithFormat:@"grant_type=client_credentials&client_id=%@", _clientID];
   
+  if (_clientSecret) {
+    params = [params stringByAppendingFormat:@"&client_secret=%@", _clientSecret];
+  }
+
   NSMutableURLRequest *urlRequest = [self requestWithURL:url HTTPMethod:@"POST" andHTTPBody:params];
 
   NSURLSessionDataTask *dataTask = [_wootricSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -34,6 +34,14 @@
  @param accountToken Found in Install section of the Wootric's admin panel.
 */
 + (void)configureWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret accountToken:(NSString *)accountToken;
+
+/**
+ @discussion It configures the SDK with required parameters.
+ @param clientID Found in API section of the Wootric's admin panel.
+ @param accountToken Found in Install section of the Wootric's admin panel.
+ */
++ (void)configureWithClientID:(NSString *)clientID accountToken:(NSString *)accountToken;
+
 /**
  @discussion It shows survey if end user is eligible.
  @param viewController View controller in which you would like to display the survey.

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -40,6 +40,12 @@
   apiClient.accountToken = accountToken;
 }
 
++ (void)configureWithClientID:(NSString *)clientID accountToken:(NSString *)accountToken {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.clientID = clientID;
+  apiClient.accountToken = accountToken;
+}
+
 + (void)setEndUserEmail:(NSString *)endUserEmail {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.endUserEmail = endUserEmail;

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -79,7 +79,6 @@
 }
 
 - (void)testCheckConfiguration {
-  
   _apiClient.clientID = @"";
   _apiClient.clientSecret = @"";
   _apiClient.accountToken = @"";
@@ -106,17 +105,16 @@
   _apiClient.accountToken = @"";
   XCTAssertFalse([_apiClient checkConfiguration]);
   
-  _apiClient.clientID = @"clientIDtestString";
-  _apiClient.clientSecret = @"";
-  _apiClient.accountToken = @"NPS-token";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  
   _apiClient.clientID = @"";
   _apiClient.clientSecret = @"clientSecretTestString";
   _apiClient.accountToken = @"NPS-token";
   XCTAssertFalse([_apiClient checkConfiguration]);
   
+  _apiClient.clientID = @"clientIDtestString";
+  _apiClient.clientSecret = @"";
+  _apiClient.accountToken = @"NPS-token";
+  XCTAssertTrue([_apiClient checkConfiguration]);
+
   _apiClient.clientID = @"clientIDtestString";
   _apiClient.clientSecret = @"clientSecretTestString";
   _apiClient.accountToken = @"NPS-token";


### PR DESCRIPTION
Add a method to authenticate SDK just with client_id. This way we
will use a new scope that restricts actions that can be done with
the token received.

## Changes
- Add new method that just needs client_id
- Update SDK to not required client_secret
- Update tests

## How to test
- Checkout this branch
- Use the new method that only requires a `client_id`
```obj_c
  NSString *clientID = @"YOUR_CLIENT_ID";
  NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
  
  [Wootric configureWithClientID:clientID accountToken:accountToken];
```
- Create responses, declines and check in the dashboard that they have been created correctly

## Trello
https://trello.com/c/nQj4hhQD/3099-poka-mobile-sdk-security