### PR TITLE
 Add Opt out to SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.0 (2018-05-21)
+
+### Changes:
+
+- Add opt out option
+
 ## 0.8.0 (2018-05-15)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.8.0"
+	pod "WootricSDK", "~> 0.9.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.8.0'
+  s.version  = '0.9.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/SEGWootric.h
+++ b/WootricSDK/WootricSDK/SEGWootric.h
@@ -85,4 +85,9 @@
 - (void)setThankYouButtonBackgroundColor:(UIColor *)color;
 - (void)setSocialSharingColor:(UIColor *)color;
 
+- (void)setLogLevelNone;
+- (void)setLogLevelError;
+- (void)setLogLevelVerbose;
+- (void)showOptOut:(BOOL)flag;
+
 @end

--- a/WootricSDK/WootricSDK/SEGWootric.m
+++ b/WootricSDK/WootricSDK/SEGWootric.m
@@ -91,6 +91,10 @@
   [Wootric forceSurvey:flag];
 }
 
+- (void)showOptOut:(BOOL)flag {
+  [Wootric showOptOut:flag];
+}
+
 - (void)skipFeedbackScreenForPromoter:(BOOL)flag {
   [Wootric skipFeedbackScreenForPromoter:flag];
 }
@@ -169,6 +173,20 @@
 
 - (void)setThankYouButtonBackgroundColor:(UIColor *)color {
   [Wootric setThankYouButtonBackgroundColor:color];
+}
+
+#pragma mark - WTRLogger setters
+
+- (void)setLogLevelNone {
+  [Wootric setLogLevelNone];
+}
+
+- (void)setLogLevelError {
+  [Wootric setLogLevelError];
+}
+
+- (void)setLogLevelVerbose {
+  [Wootric setLogLevelVerbose];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRApiClient.h
+++ b/WootricSDK/WootricSDK/WTRApiClient.h
@@ -40,4 +40,8 @@
 - (void)endUserDeclined;
 - (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text;
 
+- (NSString *)getUniqueLink;
+- (NSString *)getEndUserId;
+- (NSString *)getToken;
+
 @end

--- a/WootricSDK/WootricSDK/WTRColor.h
+++ b/WootricSDK/WootricSDK/WTRColor.h
@@ -38,6 +38,7 @@
 + (UIColor *)sendButtonBackgroundColor;
 + (UIColor *)sendButtonDisabledBackgroundColor;
 + (UIColor *)poweredByColor;
++ (UIColor *)optOutTextColor;
 + (UIColor *)wootricTextColor;
 + (UIColor *)sliderValueColor;
 + (UIColor *)sliderDotSelectedColor;

--- a/WootricSDK/WootricSDK/WTRColor.m
+++ b/WootricSDK/WootricSDK/WTRColor.m
@@ -70,6 +70,10 @@
   return [self colorWithHexString:@"#AFAFAF"];
 }
 
++ (UIColor *)optOutTextColor {
+  return [self colorWithHexString:@"AFAFAF"];
+}
+
 + (UIColor *)wootricTextColor {
   return [self colorWithHexString:@"4A4A4A"];
 }

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -34,7 +34,6 @@
 @property (nonatomic, strong) UILabel *questionLabel;
 @property (nonatomic, strong) UILabel *likelyAnchor;
 @property (nonatomic, strong) UILabel *notLikelyAnchor;
-@property (nonatomic, strong) UIButton *poweredByWootric;
 @property (nonatomic, strong) WTRSlider *scoreSlider;
 @property (nonatomic, strong) WTRScoreView *scoreLabel;
 @property (nonatomic, strong) WTRSettings *settings;

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -55,6 +55,7 @@
 @property (nonatomic, assign) NSInteger timeDelay;
 @property (nonatomic, assign) BOOL surveyImmediately;
 @property (nonatomic, assign) BOOL forceSurvey;
+@property (nonatomic, assign) BOOL showOptOut;
 @property (nonatomic, assign) BOOL setDefaultAfterSurvey;
 @property (nonatomic, assign) BOOL skipFeedbackScreen;
 @property (nonatomic, assign) BOOL passScoreAndTextToURL;

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -53,6 +53,7 @@
     _timeDelay = -1;
     _surveyType = @"NPS";
     _scale = [self scoreRules][_surveyType][0];
+    _showOptOut = NO;
   }
     
   return self;

--- a/WootricSDK/WootricSDK/WTRSurvey.m
+++ b/WootricSDK/WootricSDK/WTRSurvey.m
@@ -53,7 +53,6 @@
 }
 
 - (void)survey:(void (^)(void))showSurvey {
-    
   [WTRDefaults setLastSeenAt];
   [WTRDefaults checkIfSurveyedDefaultExpired];
   

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.h
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.h
@@ -27,5 +27,6 @@
 @interface WTRSurveyViewController (Constraints)
 
 - (void)setupConstraints;
+- (void)setupPoweredByWootricConstraintsCenteredX;
 
 @end

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Constraints.m
@@ -39,19 +39,24 @@
   [self setupSendButtonConstraints];
   [self setupDismissButtonConstraints];
   [self setupPoweredByWootricConstraints];
+  if ([self.settings showOptOut]) {
+    [self setupOptOutButtonConstraints];
+  } else {
+    [self setupPoweredByWootricConstraintsCenteredX];
+  }
 }
 
 #pragma mark - Buttons
 
 - (void)setupPoweredByWootricConstraints {
-  NSLayoutConstraint *constX = [NSLayoutConstraint constraintWithItem:self.poweredByWootric
-                                                            attribute:NSLayoutAttributeCenterX
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:self.modalView
-                                                            attribute:NSLayoutAttributeCenterX
-                                                           multiplier:1
-                                                             constant:0];
-  [self.modalView addConstraint:constX];
+  self.constraintPoweredByWootricX = [NSLayoutConstraint constraintWithItem:self.poweredByWootric
+                                                                  attribute:NSLayoutAttributeRight
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:self.modalView
+                                                                  attribute:NSLayoutAttributeRight
+                                                                 multiplier:1
+                                                                   constant:-17];
+  [self.modalView addConstraint:self.constraintPoweredByWootricX];
 
   NSLayoutConstraint *constBottom = [NSLayoutConstraint constraintWithItem:self.poweredByWootric
                                                                  attribute:NSLayoutAttributeBottom
@@ -70,6 +75,47 @@
                                                            multiplier:1
                                                              constant:12];
   [self.poweredByWootric addConstraint:constH];
+}
+
+- (void)setupPoweredByWootricConstraintsCenteredX {
+  [self.poweredByWootric removeConstraint:self.constraintPoweredByWootricX];
+  self.constraintPoweredByWootricX = [NSLayoutConstraint constraintWithItem:self.poweredByWootric
+                                                                  attribute:NSLayoutAttributeCenterX
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:self.modalView
+                                                                  attribute:NSLayoutAttributeCenterX
+                                                                 multiplier:1
+                                                                   constant:0];
+  [self.modalView addConstraint:self.constraintPoweredByWootricX];
+}
+
+- (void)setupOptOutButtonConstraints {
+  NSLayoutConstraint *constL = [NSLayoutConstraint constraintWithItem:self.optOutButton
+                                                            attribute:NSLayoutAttributeLeft
+                                                            relatedBy:NSLayoutRelationEqual
+                                                               toItem:self.modalView
+                                                            attribute:NSLayoutAttributeLeft
+                                                           multiplier:1
+                                                             constant:17];
+  [self.modalView addConstraint:constL];
+
+  NSLayoutConstraint *constBottom = [NSLayoutConstraint constraintWithItem:self.optOutButton
+                                                                 attribute:NSLayoutAttributeBottom
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:self.modalView
+                                                                 attribute:NSLayoutAttributeBottom
+                                                                multiplier:1
+                                                                  constant:-14];
+  [self.modalView addConstraint:constBottom];
+
+  NSLayoutConstraint *constH = [NSLayoutConstraint constraintWithItem:self.optOutButton
+                                                            attribute:NSLayoutAttributeHeight
+                                                            relatedBy:NSLayoutRelationEqual
+                                                               toItem:nil
+                                                            attribute:NSLayoutAttributeNotAnAttribute
+                                                           multiplier:1
+                                                             constant:12];
+  [self.optOutButton addConstraint:constH];
 }
 
 - (void)setupDismissButtonConstraints {

--- a/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController+Views.m
@@ -26,6 +26,8 @@
 #import "WTRColor.h"
 #import "UIImage+ImageFromColor.h"
 
+static NSString *const kPoweredByWootric = @"Powered by Wootric";
+
 @implementation WTRSurveyViewController (Views)
 
 - (void)setupViews {
@@ -37,6 +39,9 @@
   [self setupFinalThankYouLabel];
   [self setupSendButton];
   [self setupDismissButton];
+  if ([self.settings showOptOut]) {
+    [self setupOptOut];
+  }
   [self setupPoweredByWootric];
 
   [self addViewsToModal];
@@ -93,7 +98,7 @@
 - (void)setupPoweredByWootric {
   self.poweredByWootric = [[UIButton alloc] init];
   [self.poweredByWootric setTranslatesAutoresizingMaskIntoConstraints:NO];
-  NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Powered by Wootric"]];
+  NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:kPoweredByWootric];
   [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor poweredByColor] range:NSMakeRange(0, 10)];
   [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor wootricTextColor] range:NSMakeRange(11, 7)];
   [attrStr addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:10] range:NSMakeRange(0, 18)];
@@ -101,6 +106,17 @@
   [self.poweredByWootric addTarget:self
                       action:NSSelectorFromString(@"openWootricHomepage:")
             forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)setupOptOut {
+  self.optOutButton = [[UIButton alloc] init];
+  [self.optOutButton setTranslatesAutoresizingMaskIntoConstraints:NO];
+  [self.optOutButton setTitle:@"opt out" forState:UIControlStateNormal];
+  [self.optOutButton setTitleColor:[WTRColor optOutTextColor] forState:UIControlStateNormal];
+  [self.optOutButton.titleLabel setFont:[UIFont systemFontOfSize:10]];
+  [self.optOutButton addTarget:self
+                            action:NSSelectorFromString(@"optOutButtonPressed:")
+                  forControlEvents:UIControlEventTouchUpInside];
 }
 
 #pragma mark - Modals
@@ -131,6 +147,9 @@
   [self.modalView addSubview:self.modalView.dismissButton];
   [self.modalView addSubview:self.finalThankYouLabel];
   [self.modalView addSubview:self.sendButton];
+  if ([self.settings showOptOut]) {
+    [self.modalView addSubview:self.optOutButton];
+  }
   [self.modalView addSubview:self.poweredByWootric];
 }
 

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.h
@@ -39,10 +39,12 @@
 @property (nonatomic, strong) WTRSocialShareView *socialShareView;
 @property (nonatomic, strong) UIButton *sendButton;
 @property (nonatomic, strong) UIButton *poweredByWootric;
+@property (nonatomic, strong) UIButton *optOutButton;
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) NSLayoutConstraint *constraintTopToModalTop;
 @property (nonatomic, strong) NSLayoutConstraint *socialShareViewHeightConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *constraintModalHeight;
+@property (nonatomic, strong) NSLayoutConstraint *constraintPoweredByWootricX;
 @property (nonatomic, strong) WTRSettings *settings;
 @property (nonatomic, strong) UILabel *finalThankYouLabel;
 

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
@@ -38,6 +38,9 @@
   [self.socialShareView setupSubviewsConstraints];
   [self setupFinalThankYouLabelConstraints];
   [self setupPoweredByWootricConstraints];
+  if ([self.settings showOptOut]) {
+    [self setupOptOutButtonConstraints];
+  }
   [self setupDismissButtonConstraints];
 }
 
@@ -45,6 +48,12 @@
   [self.poweredByWootric wtr_constraintHeight:12];
   [[[self.poweredByWootric wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
   [[[[self.poweredByWootric wtr_bottomConstraint] toSecondViewBottom:self.modalView] withConstant:-14] addToView:self.modalView];
+}
+
+- (void)setupOptOutButtonConstraints {
+  [self.optOutButton wtr_constraintHeight:12];
+  [[[[self.optOutButton wtr_leftConstraint] toSecondViewRight:self.poweredByWootric] withConstant:4] addToView:self.modalView];
+  [[[[self.optOutButton wtr_bottomConstraint] toSecondViewBottom:self.modalView] withConstant:-14] addToView:self.modalView];
 }
 
 - (void)setupScrollViewConstraints {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.h
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.h
@@ -27,5 +27,6 @@
 @interface WTRiPADSurveyViewController (Views)
 
 - (void)setupViews;
+- (void)setupPoweredByWootricForSocialShareView;
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Views.m
@@ -25,6 +25,9 @@
 #import "WTRiPADSurveyViewController+Views.h"
 #import "WTRColor.h"
 
+static NSString * const kPoweredByWootric = @"Powered by Wootric";
+static NSString * const kPoweredByWootricOptOut = @"Powered by Wootric •";
+
 @implementation WTRiPADSurveyViewController (Views)
 
 - (void)setupViews {
@@ -35,7 +38,12 @@
   [self setupSocialShareView];
   [self setupFinalThankYouLabel];
   [self setupDismissButton];
-  [self setupPoweredByWootric];
+  if ([self.settings showOptOut]) {
+    [self setupPoweredByWootric:kPoweredByWootricOptOut];
+    [self setupOptOutButton];
+  } else {
+    [self setupPoweredByWootric:kPoweredByWootric];
+  }
 
   [self addViewsToModal];
   [self.view addSubview:self.scrollView];
@@ -48,6 +56,7 @@
   [self.modalView addSubview:self.socialShareView];
   [self.modalView addSubview:self.finalThankYouLabel];
   [self.modalView addSubview:self.poweredByWootric];
+  [self.modalView addSubview:self.optOutButton];
   [self.modalView addSubview:self.dismissButton];
 }
 
@@ -90,17 +99,36 @@
   [self.finalThankYouLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
 }
 
-- (void)setupPoweredByWootric {
+- (void)setupPoweredByWootric:(NSString *)text {
   self.poweredByWootric = [[UIButton alloc] init];
   [self.poweredByWootric setTranslatesAutoresizingMaskIntoConstraints:NO];
-  NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Powered by Wootric"]];
-  [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor poweredByColor] range:NSMakeRange(0, 10)];
+  NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:text];
+  [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor poweredByColor] range:NSMakeRange(0, text.length)];
   [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor iPadPoweredByWootricTextColor] range:NSMakeRange(11, 7)];
-  [attrStr addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:10] range:NSMakeRange(0, 18)];
+  [attrStr addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:10] range:NSMakeRange(0, text.length)];
   [self.poweredByWootric setAttributedTitle:attrStr forState:UIControlStateNormal];
   [self.poweredByWootric addTarget:self
                             action:NSSelectorFromString(@"openWootricHomepage:")
                   forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)setupPoweredByWootricForSocialShareView {
+  NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:kPoweredByWootric]];
+  [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor poweredByColor] range:NSMakeRange(0, 18)];
+  [attrStr addAttribute:NSForegroundColorAttributeName value:[WTRColor iPadPoweredByWootricTextColor] range:NSMakeRange(11, 7)];
+  [attrStr addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:10] range:NSMakeRange(0, 18)];
+  [self.poweredByWootric setAttributedTitle:attrStr forState:UIControlStateNormal];
+}
+
+- (void)setupOptOutButton {
+  self.optOutButton = [[UIButton alloc] init];
+  [self.optOutButton setTranslatesAutoresizingMaskIntoConstraints:NO];
+  [self.optOutButton setTitle:@"opt out" forState:UIControlStateNormal];
+  [self.optOutButton setTitleColor:[WTRColor optOutTextColor] forState:UIControlStateNormal];
+  [self.optOutButton.titleLabel setFont:[UIFont systemFontOfSize:10]];
+  [self.optOutButton addTarget:self
+                        action:NSSelectorFromString(@"optOutButtonPressed:")
+              forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)setupModalView {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
@@ -34,6 +34,7 @@
 @property (nonatomic, strong) WTRSettings *settings;
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIButton *poweredByWootric;
+@property (nonatomic, strong) UIButton *optOutButton;
 @property (nonatomic, strong) UIButton *dismissButton;
 @property (nonatomic, strong) WTRiPADModalView *modalView;
 @property (nonatomic, strong) WTRiPADQuestionView *questionView;

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -266,5 +266,10 @@
  @discussion Set WTRLogger level to Verbose i.e. it will show all logs from the WootricSDK.
  */
 + (void)setLogLevelVerbose;
+/**
+ @discussion If showOptOut is set to YES, it will show an option for the end user to opt out of being surveyed. Default value is NO.
+ @param flag A boolean to show the opt out option.
+ */
++ (void)showOptOut:(BOOL)flag;
 
 @end

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -102,6 +102,11 @@
   apiClient.settings.forceSurvey = flag;
 }
 
++ (void)showOptOut:(BOOL)flag {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.settings.showOptOut = flag;
+}
+
 + (void)surveyImmediately:(BOOL)flag {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.surveyImmediately = flag;

--- a/WootricSDK/WootricSDKTests/SEGWootricTests.m
+++ b/WootricSDK/WootricSDKTests/SEGWootricTests.m
@@ -264,4 +264,16 @@
   _apiClient.settings.socialSharingColor = nil;
 }
 
+- (void)testShowOptOutDefaultNo {
+  XCTAssertFalse(_apiClient.settings.showOptOut, @"showOptOut default value should be NO");
+}
+
+- (void)testSetShowOptOut {
+  [_segWootric showOptOut:YES];
+
+  XCTAssertTrue(_apiClient.settings.showOptOut, @"showOptOut default value should be YES");
+
+  _apiClient.settings.showOptOut = NO;
+}
+
 @end

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -38,7 +38,7 @@
 @property (nonatomic, strong) NSString *surveyServerURL;
 @property (nonatomic, strong) NSString *accessToken;
 @property (nonatomic, strong) NSURLSession *wootricSession;
-@property (nonatomic, strong) NSNumber *userID;
+@property (nonatomic) NSInteger userID;
 @property (nonatomic, strong) NSNumber *accountID;
 @property (nonatomic, strong) NSString *uniqueLink;
 @property (nonatomic, strong) NSString *osVersion;
@@ -51,7 +51,7 @@
 - (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID;
 - (void)getEndUserWithEmail:(void (^)(NSInteger endUserID))endUserWithID;
 - (void)authenticate:(void (^)(void))authenticated;
-- (NSString *)paramsWithScore:(NSInteger)score endUserID:(long)endUserID userID:(NSNumber *)userID accountID:(NSNumber *)accountID uniqueLink:(nonnull NSString *)uniqueLink priority:(int)priority text:(nullable NSString *)text;
+- (NSString *)paramsWithScore:(NSInteger)score endUserID:(long)endUserID accountID:(NSNumber *)accountID uniqueLink:(nonnull NSString *)uniqueLink priority:(int)priority text:(nullable NSString *)text;
 - (NSString *)randomString;
 - (NSString *)buildUniqueLinkAccountToken:(NSString *)accountToken endUserEmail:(NSString *)endUserEmail date:(NSTimeInterval)date randomString:(NSString *)randomString;
 - (NSString *)addSurveyServerCustomSettingsToURLString:(NSString *)baseURLString;
@@ -73,6 +73,9 @@
   _apiClient.settings.surveyImmediately = NO;
   _apiClient.settings.firstSurveyAfter = @0;
   _apiClient.priority = 0;
+  _apiClient.userID = 0;
+  _apiClient.uniqueLink = nil;
+  _apiClient.accessToken = nil;
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setBool:NO forKey:@"surveyed"];
   [defaults setDouble:0 forKey:@"lastSeenAt"];
@@ -249,24 +252,23 @@
   _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
   NSInteger score = 9;
   NSInteger endUserID = 12345678;
-  NSNumber *userID = nil;
   NSNumber *accountID = nil;
   NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
   NSString *text = nil;
   int priority = 0;
   
-  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
   XCTAssertEqualObjects(params, expectedResponse, "Should not have account_id nor text in params");
   
-  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
   XCTAssertEqualObjects(params, expectedResponse, "Should not have account_id nor text in params");
   
   accountID = @1234;
-  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
   XCTAssertEqualObjects(params, expectedResponseAccountId);
   
   text = @"test";
-  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
   XCTAssertEqualObjects(params, expectedResponseAccountIdText);
 }
 
@@ -277,34 +279,57 @@
   
   _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
   NSInteger endUserID = 12345678;
-  NSNumber *userID = nil;
   NSNumber *accountID = nil;
   NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
   int priority = 0;
   
-  NSString *params = [_apiClient paramsWithScore:-1 endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  NSString *params = [_apiClient paramsWithScore:-1 endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
   XCTAssertEqualObjects(params, expectedResponse);
   
   accountID = @1234;
-  params = [_apiClient paramsWithScore:-1 endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
+  params = [_apiClient paramsWithScore:-1 endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:nil];
   XCTAssertEqualObjects(params, expectedResponseAccountId);
 }
 
 - (void)testPriorityIncreases {
-  
   _apiClient.settings.originURL = @"com.wootric.WootricSDK-Demo";
   NSInteger score = 9;
   NSInteger endUserID = 12345678;
-  NSNumber *userID = nil;
   NSNumber *accountID = nil;
   NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
   _apiClient.priority = 0;
   
-  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  NSString *params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
   XCTAssertEqual(_apiClient.priority, 1, "priority should be 1");
-  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
-  params = [_apiClient paramsWithScore:score endUserID:endUserID userID:userID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
+  params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:_apiClient.priority text:nil];
   XCTAssertEqual(_apiClient.priority, 3, "priority should be 3");
 }
 
+- (void)testGetUniqueLinkWhenUniqueLinkIsSet {
+  NSString *uniqueLink = @"5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e";
+  _apiClient.uniqueLink = uniqueLink;
+
+  XCTAssertEqualObjects([_apiClient getUniqueLink], uniqueLink, "uniqueLink not equal");
+}
+
+- (void)testGetUniqueLinkWhenUniqueLinkIsNotSet {
+  _apiClient.uniqueLink = nil;
+
+  XCTAssertNotNil([_apiClient getUniqueLink], "uniqueLink should not be nil");
+}
+
+- (void)testGetEndUserId {
+  NSInteger userId = 12345;
+  _apiClient.userID = userId;
+
+  XCTAssertEqualObjects([_apiClient getEndUserId], @"12345", "userID not equal");
+}
+
+- (void)testGetToken {
+  NSString *token = @"5d8220d5b96ec1e0c4";
+  _apiClient.accessToken = token;
+
+  XCTAssertEqualObjects([_apiClient getToken], token, "token not equal");
+}
 @end

--- a/WootricSDK/WootricSDKTests/WTRDefaultsTests.m
+++ b/WootricSDK/WootricSDKTests/WTRDefaultsTests.m
@@ -42,14 +42,14 @@
 }
 
 - (void)tearDown {
-  [super tearDown];
-  
   [_defaults setObject:nil forKey:@"type"];
   [_defaults setObject:nil forKey:@"surveyed"];
   [_defaults setObject:nil forKey:@"lastSeenAt"];
   [_defaults setObject:nil forKey:@"surveyedAt"];
   _apiClient.settings.surveyedDefaultDurationDecline = 30;
   _apiClient.settings.surveyedDefaultDuration = 90;
+
+  [super tearDown];
 }
 
 - (void)testSetLastSeenAtNotSet {


### PR DESCRIPTION
This PR adds opt out functionality to iOS SDK.

## Changes
- Update smartphone and tablets UI
- Update tests
- Add opt out functionality

## How to test

To enable opt out you should use the newly added method 
```
[Wootric showOptOut:YES];
```
Testing should be straightforward. Just remember the different scenarios:
- Test both smartphones and tablets
- Test selecting all three options:
  - `No, the surveys are fine`
  - `Don't show me a survey for awhile`
  - `Yes, opt me out of all future surveys`

Check the console to see everything is correct
```
a = Account.find_by_account_token 'NPS-1234qwer'
eu = a.end_users.where(email: 'test@email.com').take
ap eu
ap eu.settings
```
Depending on the option you selected, the values should be different.
**No, the surveys are fine:** Nothing should change.
**Don't show me a survey for awhile:** A new decline should be created for the end user.
**Yes, opt me out of all future surveys:** A new decline should be created and the `EndUserSettings` should be something like this
```
#<EndUserSettings:0x000055baaf3eb510> {
                              :id => 71320245,
                     :end_user_id => 71495759,
                       :email_nps => false,
                      :created_at => Wed, 16 May 2018 16:16:36 PDT -07:00,
                      :updated_at => Wed, 16 May 2018 16:16:36 PDT -07:00,
                         :web_nps => false,
                      :mobile_nps => false,
             :force_mobile_survey => nil,
                :force_web_survey => nil,
    :surveys_disabled_by_end_user => true
}
```

- Also check that the opt out button disappears for the social share view (the third view)

## Trello
https://trello.com/c/qc8lu3Xf/16-2-gdpr-ios-sdk

## Note
- I left various commits for easier reviewing. All these will be squashed once this PR has been approved.