### PR TITLE
Add NSNotification for 'appear' events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.0 (2018-06-25)
+
+### Changes:
+
+- Add notifications for `appear` events (willAppear, didAppear, willDisappear, didDisappear)
+
 ## 0.9.0 (2018-05-21)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.9.0"
+	pod "WootricSDK", "~> 0.10.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.9.0'
+  s.version  = '0.10.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -7,8 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F963EF720E14D5D001EE0D2 /* WTRNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */; };
+		0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */; };
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
 		0FD5920F1D99EB0500DD173B /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */; };
+		0FE0F3F920DC041B00499248 /* WTRNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */; };
+		0FE0F3FD20DC059700499248 /* WTRDefaultNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */; };
+		0FE0F3FE20DC059700499248 /* WTRDefaultNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0F3FC20DC059700499248 /* WTRDefaultNotificationCenter.m */; };
+		0FE0F40320DC0D4800499248 /* WTRMockNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0F40220DC0D4800499248 /* WTRMockNotificationCenter.m */; };
+		0FE0F40920DC1AE000499248 /* WTRSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0F40820DC1AE000499248 /* WTRSurveyViewControllerTests.m */; };
 		0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */; };
 		0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */; };
 		178571982088FCA800CCBE02 /* WTRLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 178571962088FCA700CCBE02 /* WTRLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -113,8 +120,16 @@
 
 /* Begin PBXFileReference section */
 		0F04153A1FA8F11000E3C926 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRNotificationCenter.m; sourceTree = "<group>"; };
+		0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRiPADSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
 		0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
+		0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRNotificationCenter.h; sourceTree = "<group>"; };
+		0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRDefaultNotificationCenter.h; sourceTree = "<group>"; };
+		0FE0F3FC20DC059700499248 /* WTRDefaultNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRDefaultNotificationCenter.m; sourceTree = "<group>"; };
+		0FE0F40120DC0D4800499248 /* WTRMockNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRMockNotificationCenter.h; sourceTree = "<group>"; };
+		0FE0F40220DC0D4800499248 /* WTRMockNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRMockNotificationCenter.m; sourceTree = "<group>"; };
+		0FE0F40820DC1AE000499248 /* WTRSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRApiClientTests.m; sourceTree = "<group>"; };
 		0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRDefaultsTests.m; sourceTree = "<group>"; };
 		178571962088FCA700CCBE02 /* WTRLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRLogger.h; sourceTree = "<group>"; };
@@ -228,6 +243,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0FE0F40020DC0D2900499248 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				0FE0F40120DC0D4800499248 /* WTRMockNotificationCenter.h */,
+				0FE0F40220DC0D4800499248 /* WTRMockNotificationCenter.m */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		0FE0F40520DC1A9E00499248 /* iPad */ = {
+			isa = PBXGroup;
+			children = (
+				0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */,
+			);
+			path = iPad;
+			sourceTree = "<group>";
+		};
+		0FE0F40720DC1ACE00499248 /* iPhone */ = {
+			isa = PBXGroup;
+			children = (
+				0FE0F40820DC1AE000499248 /* WTRSurveyViewControllerTests.m */,
+			);
+			path = iPhone;
+			sourceTree = "<group>";
+		};
 		B260ECE31BD8D7F200E29CD5 /* SimpleConstraints */ = {
 			isa = PBXGroup;
 			children = (
@@ -354,6 +394,10 @@
 				178571962088FCA700CCBE02 /* WTRLogger.h */,
 				178571972088FCA700CCBE02 /* WTRLogger.m */,
 				1785719A2088FD1500CCBE02 /* WTRLogLevel.h */,
+				0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */,
+				0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */,
+				0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */,
+				0FE0F3FC20DC059700499248 /* WTRDefaultNotificationCenter.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -422,6 +466,9 @@
 		B2DC6F111B81E6F900F599B3 /* WootricSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				0FE0F40720DC1ACE00499248 /* iPhone */,
+				0FE0F40520DC1A9E00499248 /* iPad */,
+				0FE0F40020DC0D2900499248 /* Mocks */,
 				B21372951BED0DB1009F5974 /* WTRSurveyTests.m */,
 				0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */,
 				B29D63C91BC3CEEB00F0C98C /* WTRSettingsTests.m */,
@@ -470,6 +517,7 @@
 				B22976811BB2A2C300FC2772 /* WTRSocialShareView.h in Headers */,
 				B26866761BD5444F00A4288D /* WTRiPADSurveyViewController+Constraints.h in Headers */,
 				B260ECDD1BD7E5B200E29CD5 /* UIView+Constraints.h in Headers */,
+				0FE0F3FD20DC059700499248 /* WTRDefaultNotificationCenter.h in Headers */,
 				B268667E1BD63B7000A4288D /* WTRCircleScoreButton.h in Headers */,
 				7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */,
 				B24550A51B909AC9001AC1FB /* WTRSurveyViewController+Constraints.h in Headers */,
@@ -478,6 +526,7 @@
 				B2102A331BB59ACE0025DABC /* WTRCustomMessages.h in Headers */,
 				B2102A3B1BB59AE60025DABC /* WTRSurvey.h in Headers */,
 				B260ECE11BD8D7E300E29CD5 /* NSLayoutConstraint+Simple.h in Headers */,
+				0FE0F3F920DC041B00499248 /* WTRNotificationCenter.h in Headers */,
 				B22976751BB1404D00FC2772 /* WTRCustomThankYou.h in Headers */,
 				B24550911B8E0188001AC1FB /* WTRColor.h in Headers */,
 				B229766D1BB0036100FC2772 /* WTRPropertiesParser.h in Headers */,
@@ -603,6 +652,7 @@
 				B2C940691BA71A2900482494 /* WTRSliderDot.m in Sources */,
 				B26866831BD63ED100A4288D /* WTRCircleScoreView.m in Sources */,
 				B26866871BD63F8B00A4288D /* WTRiPADModalView.m in Sources */,
+				0FE0F3FE20DC059700499248 /* WTRDefaultNotificationCenter.m in Sources */,
 				B2102A341BB59ACE0025DABC /* WTRCustomMessages.m in Sources */,
 				B22976761BB1404D00FC2772 /* WTRCustomThankYou.m in Sources */,
 				B229766E1BB0036100FC2772 /* WTRPropertiesParser.m in Sources */,
@@ -617,6 +667,7 @@
 				B2C9406D1BA83E6200482494 /* WTRScoreView.m in Sources */,
 				B278897A1BE0E168001D5696 /* WTRiPADSocialShareView.m in Sources */,
 				B26866731BD5443000A4288D /* WTRiPADSurveyViewController+Views.m in Sources */,
+				0F963EF720E14D5D001EE0D2 /* WTRNotificationCenter.m in Sources */,
 				B245509E1B909A03001AC1FB /* WTRSurveyViewController.m in Sources */,
 				B24550A61B909AC9001AC1FB /* WTRSurveyViewController+Constraints.m in Sources */,
 				B2C940611BA300A000482494 /* WTRSlider.m in Sources */,
@@ -648,11 +699,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */,
 				B29D63CA1BC3CEEB00F0C98C /* WTRSettingsTests.m in Sources */,
+				0FE0F40320DC0D4800499248 /* WTRMockNotificationCenter.m in Sources */,
 				0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */,
 				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
 				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,
+				0FE0F40920DC1AE000499248 /* WTRSurveyViewControllerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRDefaultNotificationCenter.h
+++ b/WootricSDK/WootricSDK/WTRDefaultNotificationCenter.h
@@ -1,0 +1,29 @@
+//
+//  WTRDefaultNotificationCenter.h
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTRNotificationCenter.h"
+
+@interface WTRDefaultNotificationCenter : WTRNotificationCenter
+- (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter;
+@end

--- a/WootricSDK/WootricSDK/WTRDefaultNotificationCenter.m
+++ b/WootricSDK/WootricSDK/WTRDefaultNotificationCenter.m
@@ -1,0 +1,52 @@
+//
+//  WTRDefaultNotificationCenter.m
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTRDefaultNotificationCenter.h"
+
+@interface WTRDefaultNotificationCenter ()
+@property (nonatomic, strong) NSNotificationCenter *notificationCenter;
+@end
+
+@implementation WTRDefaultNotificationCenter
+
+- (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter {
+  if (self = [super init]) {
+    _notificationCenter = notificationCenter;
+  }
+  return self;
+}
+
+- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject {
+  [_notificationCenter addObserver:observer selector:aSelector name:aName object:anObject];
+}
+
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject {
+  [_notificationCenter postNotificationName:aName object:anObject];
+}
+
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo {
+  [_notificationCenter postNotificationName:aName object:anObject userInfo:aUserInfo];
+}
+
+@end

--- a/WootricSDK/WootricSDK/WTRNotificationCenter.h
+++ b/WootricSDK/WootricSDK/WTRNotificationCenter.h
@@ -1,0 +1,31 @@
+//
+//  WTRNotificationCenter.h
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface WTRNotificationCenter : NSObject
+- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject;
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject;
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo;
+@end

--- a/WootricSDK/WootricSDK/WTRNotificationCenter.m
+++ b/WootricSDK/WootricSDK/WTRNotificationCenter.m
@@ -1,0 +1,32 @@
+//
+//  WTRNotificationCenter.m
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTRNotificationCenter.h"
+
+@implementation WTRNotificationCenter
+
+- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject {}
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject {}
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo {}
+@end

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.h
@@ -25,6 +25,7 @@
 #import <UIKit/UIKit.h>
 #import "WTRModalView.h"
 #import "WTRSettings.h"
+#import "WTRNotificationCenter.h"
 #import "WTRQuestionView.h"
 #import "WTRFeedbackView.h"
 #import "WTRSocialShareView.h"
@@ -48,6 +49,6 @@
 @property (nonatomic, strong) WTRSettings *settings;
 @property (nonatomic, strong) UILabel *finalThankYouLabel;
 
-- (instancetype)initWithSurveySettings:(WTRSettings *)settings;
+- (instancetype)initWithSurveySettings:(WTRSettings *)settings notificationCenter:(WTRNotificationCenter *)notificationCenter;
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
@@ -24,6 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import "WTRSettings.h"
+#import "WTRNotificationCenter.h"
 #import "WTRiPADModalView.h"
 #import "WTRiPADQuestionView.h"
 #import "WTRiPADFeedbackView.h"
@@ -46,6 +47,6 @@
 @property (nonatomic, strong) NSLayoutConstraint *socialShareViewHeightConstraint;
 @property (nonatomic, strong) UILabel *finalThankYouLabel;
 
-- (instancetype)initWithSurveySettings:(WTRSettings *)settings;
+- (instancetype)initWithSurveySettings:(WTRSettings *)settings notificationCenter:(WTRNotificationCenter *)notificationCenter;
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -32,6 +32,8 @@
 #import "WTRLogger.h"
 #import "WTRApiClient.h"
 #import "NSString+FontAwesome.h"
+#import "WTRDefaultNotificationCenter.h"
+#import "Wootric.h"
 #import <Social/Social.h>
 
 @interface WTRiPADSurveyViewController ()
@@ -44,14 +46,16 @@
 @property (nonatomic, strong) NSString *endUserId;
 @property (nonatomic, strong) NSString *uniqueLink;
 @property (nonatomic, strong) NSString *token;
+@property (nonatomic, strong) WTRNotificationCenter *notificationCenter;
 
 @end
 
 @implementation WTRiPADSurveyViewController
 
-- (instancetype)initWithSurveySettings:(WTRSettings *)settings {
+- (instancetype)initWithSurveySettings:(WTRSettings *)settings notificationCenter:(WTRNotificationCenter *)notificationCenter {
   if (self = [super init]) {
     _settings = settings;
+    _notificationCenter = notificationCenter;
     self.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     self.modalPresentationStyle = UIModalPresentationOverCurrentContext;
   }
@@ -76,8 +80,23 @@
   [super didReceiveMemoryWarning];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+  [_notificationCenter postNotificationName:[Wootric surveyWillAppearNotification]
+                                     object:self];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
+  [_notificationCenter postNotificationName:[Wootric surveyWillDisappearNotification]
+                                     object:self];
+}
+
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
+  [_notificationCenter postNotificationName:[Wootric surveyDidAppearNotification]
+                                     object:self];
+
   [UIView animateWithDuration:0.25 animations:^{
     self.view.backgroundColor = [WTRColor viewBackgroundColor];
     CGRect modalFrame = self->_modalView.frame;
@@ -86,6 +105,13 @@
     self->_modalView.frame = modalFrame;
     self->_constraintTopToModalTop.constant = modalPosition;
   }];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+  [super viewDidDisappear:animated];
+  [_notificationCenter postNotificationName:[Wootric surveyDidDisappearNotification]
+                                     object:self
+                                   userInfo:@{@"score": @(_currentScore), @"voted": @(_alreadyVoted)}];
 }
 
 - (void)selectScore:(WTRCircleScoreButton *)sender {

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -271,5 +271,20 @@
  @param flag A boolean to show the opt out option.
  */
 + (void)showOptOut:(BOOL)flag;
-
+/**
+ @discussion Notification posted when the survey view is about to be presented.
+ */
++ (NSNotificationName)surveyWillAppearNotification;
+/**
+ @discussion Notification posted when the survey view is about to be dismissed.
+ */
++ (NSNotificationName)surveyWillDisappearNotification;
+/**
+ @discussion Notification posted when the survey view appears.
+ */
++ (NSNotificationName)surveyDidAppearNotification;
+/**
+ @discussion Notification posted when the survey view disappears, with userInfo as follows: `score` The NPS score as a NSNumber. `voted` Boolean NSNumber indicating whether the user voted or not.
+ */
++ (NSNotificationName)surveyDidDisappearNotification;
 @end

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -26,6 +26,7 @@
 #import "WTRTrackingPixel.h"
 #import "WTRSurvey.h"
 #import "WTRSurveyViewController.h"
+#import "WTRDefaultNotificationCenter.h"
 #import "WTRiPADSurveyViewController.h"
 #import "WTRApiClient.h"
 #import "WTRLogger.h"
@@ -173,10 +174,12 @@
   WTRSettings *surveySettings = [WTRApiClient sharedInstance].settings;
   
   if (IPAD) {
-    WTRiPADSurveyViewController *surveyViewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:surveySettings];
+    WTRiPADSurveyViewController *surveyViewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:surveySettings
+                                                                                                 notificationCenter:[[WTRDefaultNotificationCenter alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]]];
     [viewController presentViewController:surveyViewController animated:YES completion:nil];
   } else {
-    WTRSurveyViewController *surveyViewController = [[WTRSurveyViewController alloc] initWithSurveySettings:surveySettings];
+    WTRSurveyViewController *surveyViewController = [[WTRSurveyViewController alloc] initWithSurveySettings:surveySettings
+                                                                                         notificationCenter:[[WTRDefaultNotificationCenter alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]]];
     [viewController presentViewController:surveyViewController animated:YES completion:nil];
   }
 }
@@ -296,6 +299,24 @@
 
 + (void)setLogLevelVerbose {
   [WTRLogger setLogLevel:WTRLogLevelVerbose];
+}
+
+#pragma mark - Notifications
+
++ (NSNotificationName)surveyWillAppearNotification {
+  return @"com.wootric.surveyWillAppearNotification";
+}
+
++ (NSNotificationName)surveyWillDisappearNotification {
+  return @"com.wootric.surveyWillDisappearNotification";
+}
+
++ (NSNotificationName)surveyDidAppearNotification {
+  return @"com.wootric.surveyDidAppearNotification";
+}
+
++ (NSNotificationName)surveyDidDisappearNotification {
+  return @"com.wootric.surveyDidDisappearNotification";
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/Mocks/WTRMockNotificationCenter.h
+++ b/WootricSDK/WootricSDKTests/Mocks/WTRMockNotificationCenter.h
@@ -1,0 +1,30 @@
+//
+//  WTRMockNotificationCenter.h
+//  WootricSDKTests
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTRNotificationCenter.h"
+
+@interface WTRMockNotificationCenter : WTRNotificationCenter
+@property (nonatomic, strong) NSMutableArray *notifications;
+@property (nonatomic, strong) NSMutableArray *observers;
+@end

--- a/WootricSDK/WootricSDKTests/Mocks/WTRMockNotificationCenter.m
+++ b/WootricSDK/WootricSDKTests/Mocks/WTRMockNotificationCenter.m
@@ -1,0 +1,49 @@
+//
+//  WTRMockNotificationCenter.m
+//  WootricSDKTests
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTRMockNotificationCenter.h"
+
+@implementation WTRMockNotificationCenter
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _observers = [NSMutableArray new];
+    _notifications = [NSMutableArray new];
+  }
+  return self;
+}
+
+- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject {
+  [_observers addObject:observer];
+}
+
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject {
+  [_notifications addObject:aName];
+}
+
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo {
+  [_notifications addObject:aName];
+}
+
+@end

--- a/WootricSDK/WootricSDKTests/iPad/WTRiPADSurveyViewControllerTests.m
+++ b/WootricSDK/WootricSDKTests/iPad/WTRiPADSurveyViewControllerTests.m
@@ -1,0 +1,71 @@
+//
+//  WTRSurveyControllerTests.m
+//  WootricSDKTests
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "WTRiPADSurveyViewController.h"
+#import "WTRApiClient.h"
+#import "Wootric.h"
+#import "WTRMockNotificationCenter.h"
+
+@interface WTRiPADSurveyViewControllerTests : XCTestCase
+@property (nonatomic, strong) WTRiPADSurveyViewController *viewController;
+@property (nonatomic, strong) WTRMockNotificationCenter *notificationCenter;
+@end
+
+@implementation WTRiPADSurveyViewControllerTests
+
+- (void)setUp {
+  [super setUp];
+  _notificationCenter = [WTRMockNotificationCenter new];
+  _viewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:[WTRApiClient sharedInstance].settings
+                                                             notificationCenter:_notificationCenter];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  _notificationCenter = nil;
+  _viewController = nil;
+}
+
+- (void)testViewWillAppear {
+  [_viewController viewWillAppear:YES];
+  XCTAssertEqual([Wootric surveyWillAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillAppearNotification'");
+}
+
+- (void)testViewWillDisappear {
+  [_viewController viewWillDisappear:YES];
+  XCTAssertEqual([Wootric surveyWillDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillDisappearNotification'");
+}
+
+- (void)testViewDidAppear {
+  [_viewController viewDidAppear:YES];
+  XCTAssertEqual([Wootric surveyDidAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidAppearNotification'");
+}
+
+- (void)testViewDidDisappear {
+  [_viewController viewDidDisappear:YES];
+  XCTAssertEqual([Wootric surveyDidDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidDisappearNotification'");
+}
+
+@end

--- a/WootricSDK/WootricSDKTests/iPhone/WTRSurveyViewControllerTests.m
+++ b/WootricSDK/WootricSDKTests/iPhone/WTRSurveyViewControllerTests.m
@@ -1,0 +1,71 @@
+//
+//  WTRSurveyControllerTests.m
+//  WootricSDKTests
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "WTRSurveyViewController.h"
+#import "WTRApiClient.h"
+#import "Wootric.h"
+#import "WTRMockNotificationCenter.h"
+
+@interface WTRSurveyViewControllerTests : XCTestCase
+@property (nonatomic, strong) WTRSurveyViewController *viewController;
+@property (nonatomic, strong) WTRMockNotificationCenter *notificationCenter;
+@end
+
+@implementation WTRSurveyViewControllerTests
+
+- (void)setUp {
+  [super setUp];
+  _notificationCenter = [WTRMockNotificationCenter new];
+  _viewController = [[WTRSurveyViewController alloc] initWithSurveySettings:[WTRApiClient sharedInstance].settings
+                                                         notificationCenter:_notificationCenter];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  _notificationCenter = nil;
+  _viewController = nil;
+}
+
+- (void)testViewWillAppear {
+  [_viewController viewWillAppear:YES];
+  XCTAssertEqual([Wootric surveyWillAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillAppearNotification'");
+}
+
+- (void)testViewWillDisappear {
+  [_viewController viewWillDisappear:YES];
+  XCTAssertEqual([Wootric surveyWillDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillDisappearNotification'");
+}
+
+- (void)testViewDidAppear {
+  [_viewController viewDidAppear:YES];
+  XCTAssertEqual([Wootric surveyDidAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidAppearNotification'");
+}
+
+- (void)testViewDidDisappear {
+  [_viewController viewDidDisappear:YES];
+  XCTAssertEqual([Wootric surveyDidDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidDisappearNotification'");
+}
+
+@end


### PR DESCRIPTION
Adds notifications for events:
- surveyWillAppearNotification
- surveyWillDisappearNotification
- surveyDidAppearNotification
- surveyDidDisappearNotification

## Changes:
- Add observers for notifications

## How to test

- Add this line the `viewDidLoad` method of `ViewController`, or anywhere you prefer to test
```
[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receiveTestNotification:) name:[Wootric surveyDidDisappearNotification] object:nil];
```
Note that here we're using `surveyDidDisappearNotification`. Make sure to test all 4 notifications.

- We also need to add the selector method. Something like this should work
```
- (void) receiveTestNotification:(NSNotification *) notification
{
  if ([[notification name] isEqualToString:[Wootric surveyWillAppearNotification]]){
    NSLog (@"Survey will be presented!");
  } else if ([[notification name] isEqualToString:[Wootric surveyWillDisappearNotification]]){
    NSLog (@"Survey will disappear!");
  } else if ([[notification name] isEqualToString:[Wootric surveyDidAppearNotification]]){
    NSLog (@"Survey was presented!");
  } else if ([[notification name] isEqualToString:[Wootric surveyDidDisappearNotification]]){
    NSLog (@"Survey disappeared!");
  }
}
```

## Trello
There's no Trello card for this. It was added and requested by a customer

### Note
This PR completes the implementation proposed in PR #43 