### PR TITLE
Fix slider for right-to-left configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1 (2018-09-26)
+
+### Fixed:
+
+- Force left-to-right in slider
+
 ## 0.10.0 (2018-06-25)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.10.0"
+	pod "WootricSDK", "~> 0.10.1"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.10.0'
+  s.version  = '0.10.1'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.10.1 </string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRSlider.m
+++ b/WootricSDK/WootricSDK/WTRSlider.m
@@ -47,7 +47,9 @@
     _settings = settings;
     _sliderColor = color;
     _currentValue = -1;
-    
+
+    [self setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+
     self.minimumValue = [_settings minimumScore];
     self.maximumValue = [_settings maximumScore];
     self.value = [_settings minimumScore];


### PR DESCRIPTION
Forces the slider to go left-to-right

## How to test
1. Fire the iOS simulator, go to **Settings -> General -> Language & Region** and select **iPhone Language**, select **Hebrew** and **Done**
2. In `master`, setup the SDK with your `account_token` and `clientId` in `ViewController.m`
3. In Xcode, click on the `WootricSDK-Demo` item in the Project Navigator.
4. Now select `WootricSDK-Demo` project from the dropdown and select the `Build Settings` tab.
5. Under `Localizations`, click on the `+` and add Hebrew language.
![screen shot 2018-09-25 at 11 45 35 am](https://user-images.githubusercontent.com/1431421/46029400-f020d880-c0b8-11e8-8195-1333536e64d5.png)
6. If you run the app now and see the survey, the slider would go the wrong way.
7. Checkout this branch
8. Run app again and everything should be working fine.

## Trello
https://trello.com/c/TvozRrLL/3536-2-ios-survey-bug-the-bar-goes-the-wrong-way-watch-video