### PR TITLE
Fix bad URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.2 (2018-11-27)
+
+### Fixed:
+
+- Percentage escape strings to prevent NSURL errors
+
 ## 0.10.1 (2018-09-26)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.10.1"
+	pod "WootricSDK", "~> 0.10.2"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.10.1'
+  s.version  = '0.10.2'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -7,9 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F370D5921ACAAF10007C27A /* WTRUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F370D5721ACAAF10007C27A /* WTRUtils.h */; };
+		0F370D5A21ACAAF10007C27A /* WTRUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F370D5821ACAAF10007C27A /* WTRUtils.m */; };
 		0F963EF720E14D5D001EE0D2 /* WTRNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */; };
 		0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */; };
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
+		0FC321FE21ADE4A0000E19DF /* WTRUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */; };
 		0FD5920F1D99EB0500DD173B /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */; };
 		0FE0F3F920DC041B00499248 /* WTRNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */; };
 		0FE0F3FD20DC059700499248 /* WTRDefaultNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */; };
@@ -120,9 +123,12 @@
 
 /* Begin PBXFileReference section */
 		0F04153A1FA8F11000E3C926 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0F370D5721ACAAF10007C27A /* WTRUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRUtils.h; sourceTree = "<group>"; };
+		0F370D5821ACAAF10007C27A /* WTRUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtils.m; sourceTree = "<group>"; };
 		0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRNotificationCenter.m; sourceTree = "<group>"; };
 		0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRiPADSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
+		0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtilsTests.m; sourceTree = "<group>"; };
 		0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
 		0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRNotificationCenter.h; sourceTree = "<group>"; };
 		0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRDefaultNotificationCenter.h; sourceTree = "<group>"; };
@@ -243,6 +249,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0FC321FC21ADE482000E19DF /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		0FE0F40020DC0D2900499248 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -398,6 +412,8 @@
 				0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */,
 				0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */,
 				0FE0F3FC20DC059700499248 /* WTRDefaultNotificationCenter.m */,
+				0F370D5721ACAAF10007C27A /* WTRUtils.h */,
+				0F370D5821ACAAF10007C27A /* WTRUtils.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -466,6 +482,7 @@
 		B2DC6F111B81E6F900F599B3 /* WootricSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				0FC321FC21ADE482000E19DF /* Utils */,
 				0FE0F40720DC1ACE00499248 /* iPhone */,
 				0FE0F40520DC1A9E00499248 /* iPad */,
 				0FE0F40020DC0D2900499248 /* Mocks */,
@@ -537,6 +554,7 @@
 				B27889701BDA5520001D5696 /* WTRiPADFeedbackView.h in Headers */,
 				B2BED80C1BA8610900DD1EFC /* WTRSingleScoreLabel.h in Headers */,
 				B27889751BDF85FD001D5696 /* UIItems.h in Headers */,
+				0F370D5921ACAAF10007C27A /* WTRUtils.h in Headers */,
 				B24550A11B909A49001AC1FB /* WTRSurveyViewController+Views.h in Headers */,
 				B2C9405B1BA0723300482494 /* WTRModalView.h in Headers */,
 				B26866821BD63ED100A4288D /* WTRCircleScoreView.h in Headers */,
@@ -676,6 +694,7 @@
 				178571992088FCA800CCBE02 /* WTRLogger.m in Sources */,
 				B278897E1BE105D6001D5696 /* WTRiPADThankYouButton.m in Sources */,
 				B27889711BDA5520001D5696 /* WTRiPADFeedbackView.m in Sources */,
+				0F370D5A21ACAAF10007C27A /* WTRUtils.m in Sources */,
 				B27889761BDF85FD001D5696 /* UIItems.m in Sources */,
 				B268668B1BD671D200A4288D /* WTRiPADQuestionView.m in Sources */,
 				B24550A21B909A49001AC1FB /* WTRSurveyViewController+Views.m in Sources */,
@@ -702,6 +721,7 @@
 				0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */,
 				B29D63CA1BC3CEEB00F0C98C /* WTRSettingsTests.m in Sources */,
 				0FE0F40320DC0D4800499248 /* WTRMockNotificationCenter.m in Sources */,
+				0FC321FE21ADE4A0000E19DF /* WTRUtilsTests.m in Sources */,
 				0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */,
 				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
@@ -847,7 +867,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Debug;
 		};

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.1 </string>
+	<string>0.10.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -24,6 +24,7 @@
 
 #import "WTRApiClient.h"
 #import "WTRPropertiesParser.h"
+#import "WTRUtils.h"
 #import "WTRLogger.h"
 #import <CommonCrypto/CommonHMAC.h>
 
@@ -100,7 +101,7 @@
 }
 
 - (void)getEndUserWithEmail:(void (^)(NSInteger endUserID))endUserWithID {
-  NSString *escapedEmail = [self percentEscapeString:[_settings getEndUserEmailOrUnknown]];
+  NSString *escapedEmail = [WTRUtils percentEscapeString:[_settings getEndUserEmailOrUnknown]];
   
   escapedEmail = [self addVersionsToURLString:escapedEmail];
   
@@ -139,12 +140,12 @@
 
 - (void)updateExistingEndUser:(NSInteger)endUserID {
   BOOL needsUpdate = NO;
-  NSString *escapedEmail = [self percentEscapeString:[_settings getEndUserEmailOrUnknown]];
+  NSString *escapedEmail = [WTRUtils percentEscapeString:[_settings getEndUserEmailOrUnknown]];
   NSString *params = [NSString stringWithFormat:@"email=%@", escapedEmail];
 
   if (_settings.productName) {
     needsUpdate = YES;
-    params = [NSString stringWithFormat:@"%@&properties[product_name]=%@", params, [self percentEscapeString:_settings.productName]];
+    params = [NSString stringWithFormat:@"%@&properties[product_name]=%@", params, [WTRUtils percentEscapeString:_settings.productName]];
   }
   
   if (_settings.externalId) {
@@ -184,7 +185,7 @@
 
 - (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID {
   NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/end_users", _baseAPIURL, _apiVersion]];
-  NSString *escapedEmail = [self percentEscapeString:[_settings getEndUserEmailOrUnknown]];
+  NSString *escapedEmail = [WTRUtils percentEscapeString:[_settings getEndUserEmailOrUnknown]];
   NSString *params = [NSString stringWithFormat:@"email=%@", escapedEmail];
     
   if (_settings.externalCreatedAt) {
@@ -283,7 +284,7 @@
   baseURLString = [self addVersionsToURLString:baseURLString];
 
   if (![endUserEmail isEqual: @"Unknown"]) {
-    baseURLString = [NSString stringWithFormat:@"%@&email=%@", baseURLString, endUserEmail];
+    baseURLString = [NSString stringWithFormat:@"%@&email=%@", baseURLString, [WTRUtils percentEscapeString:endUserEmail]];
   }
 
   baseURLString = [self addSurveyServerCustomSettingsToURLString:baseURLString];
@@ -409,12 +410,12 @@
 
   if (_settings.customProductName) {
     baseURLString = [NSString stringWithFormat:@"%@&language[product_name]=%@",
-                     baseURLString, [self percentEscapeString:_settings.customProductName]];
+                     baseURLString, [WTRUtils percentEscapeString:_settings.customProductName]];
   }
 
   if (_settings.customAudience) {
     baseURLString = [NSString stringWithFormat:@"%@&language[audience_text]=%@",
-                     baseURLString, [self percentEscapeString:_settings.customAudience]];
+                     baseURLString, [WTRUtils percentEscapeString:_settings.customAudience]];
   }
 
   if ([_settings.firstSurveyAfter intValue] > 0) {
@@ -447,7 +448,7 @@
     params = [NSString stringWithFormat:@"%@&score=%ld", params, (long) score];
     
     if (text) {
-      NSString *escapedText = [self percentEscapeString:text];
+      NSString *escapedText = [WTRUtils percentEscapeString:text];
       params = [NSString stringWithFormat:@"%@&text=%@", params, escapedText];
     }
   }
@@ -459,15 +460,6 @@
   _priority++;
   
   return params;
-}
-
-- (NSString *)percentEscapeString:(NSString *)string {
-  NSString *result = CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
-                                                                               (CFStringRef)string,
-                                                                               (CFStringRef)@" ",
-                                                                               (CFStringRef)@":/?@!$&'()*+,;=",
-                                                                               kCFStringEncodingUTF8));
-  return [result stringByReplacingOccurrencesOfString:@" " withString:@"+"];
 }
 
 - (NSString *)buildUniqueLinkAccountToken:(NSString *)accountToken endUserEmail:(NSString *)endUserEmail date:(NSTimeInterval)date randomString:(NSString *)randomString {

--- a/WootricSDK/WootricSDK/WTRTrackingPixel.m
+++ b/WootricSDK/WootricSDK/WTRTrackingPixel.m
@@ -25,6 +25,7 @@
 #import "WTRTrackingPixel.h"
 #import "WTRApiClient.h"
 #import "WTRLogger.h"
+#import "WTRUtils.h"
 
 @implementation WTRTrackingPixel
 
@@ -34,7 +35,7 @@
   double cacheRandom = drand48();
   NSString *formattedRandom = [NSString stringWithFormat:@"%.16f", cacheRandom];
   NSString *stringToFormat = @"https://d8myem934l1zi.cloudfront.net/pixel.gif?account_token=%@&email=%@&url=%@&random=%@";
-  NSString *params = [NSString stringWithFormat:stringToFormat, apiClient.accountToken, apiClient.settings.endUserEmail, apiClient.settings.originURL, formattedRandom];
+  NSString *params = [NSString stringWithFormat:stringToFormat, apiClient.accountToken, [WTRUtils percentEscapeString:apiClient.settings.endUserEmail], apiClient.settings.originURL, formattedRandom];
 
   if (apiClient.settings.externalCreatedAt) {
     [WTRLogger log:@"externalCreatedAt: %ld", (long)[apiClient.settings.externalCreatedAt intValue]];

--- a/WootricSDK/WootricSDK/WTRUtils.h
+++ b/WootricSDK/WootricSDK/WTRUtils.h
@@ -1,5 +1,5 @@
 //
-//  WTRPropertiesParser.m
+//  WTRUtils.h
 //  WootricSDK
 //
 // Copyright (c) 2018 Wootric (https://wootric.com)
@@ -22,19 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "WTRPropertiesParser.h"
-#import "WTRUtils.h"
+#import <Foundation/Foundation.h>
 
-@implementation WTRPropertiesParser
+@interface WTRUtils : NSObject
 
-+ (NSString *)parseToStringFromDictionary:(NSDictionary *)dictionary {
-  NSString *parsedProperties = @"";
-  for (NSString *key in dictionary) {
-    NSString *escapedValue = [WTRUtils percentEscapeString:[NSString stringWithFormat:@"%@", [dictionary objectForKey:key]]];
-    parsedProperties = [NSString stringWithFormat:@"%@&%@", parsedProperties, [NSString stringWithFormat:@"properties[%@]=%@", key, escapedValue]];
-  }
-
-  return parsedProperties;
-}
++ (NSString *)percentEscapeString:(NSString *)string;
 
 @end

--- a/WootricSDK/WootricSDK/WTRUtils.m
+++ b/WootricSDK/WootricSDK/WTRUtils.m
@@ -1,5 +1,5 @@
 //
-//  WTRPropertiesParser.m
+//  WTRUtils.m
 //  WootricSDK
 //
 // Copyright (c) 2018 Wootric (https://wootric.com)
@@ -22,19 +22,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "WTRPropertiesParser.h"
 #import "WTRUtils.h"
 
-@implementation WTRPropertiesParser
+@implementation WTRUtils
 
-+ (NSString *)parseToStringFromDictionary:(NSDictionary *)dictionary {
-  NSString *parsedProperties = @"";
-  for (NSString *key in dictionary) {
-    NSString *escapedValue = [WTRUtils percentEscapeString:[NSString stringWithFormat:@"%@", [dictionary objectForKey:key]]];
-    parsedProperties = [NSString stringWithFormat:@"%@&%@", parsedProperties, [NSString stringWithFormat:@"properties[%@]=%@", key, escapedValue]];
-  }
-
-  return parsedProperties;
++ (NSString *)percentEscapeString:(NSString *)string {
+  NSString *result = CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+                                                                               (CFStringRef)string,
+                                                                               (CFStringRef)@" ",
+                                                                               (CFStringRef)@":/?@!$&'()*+,;=",
+                                                                               kCFStringEncodingUTF8));
+  return [result stringByReplacingOccurrencesOfString:@" " withString:@"+"];
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/Utils/WTRUtilsTests.m
+++ b/WootricSDK/WootricSDKTests/Utils/WTRUtilsTests.m
@@ -1,6 +1,6 @@
 //
-//  WTRPropertiesParser.m
-//  WootricSDK
+//  WTRUtilsTests.m
+//  WootricSDKTests
 //
 // Copyright (c) 2018 Wootric (https://wootric.com)
 //
@@ -22,19 +22,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "WTRPropertiesParser.h"
+#import <XCTest/XCTest.h>
 #import "WTRUtils.h"
 
-@implementation WTRPropertiesParser
+@interface WTRUtilsTests : XCTestCase
 
-+ (NSString *)parseToStringFromDictionary:(NSDictionary *)dictionary {
-  NSString *parsedProperties = @"";
-  for (NSString *key in dictionary) {
-    NSString *escapedValue = [WTRUtils percentEscapeString:[NSString stringWithFormat:@"%@", [dictionary objectForKey:key]]];
-    parsedProperties = [NSString stringWithFormat:@"%@&%@", parsedProperties, [NSString stringWithFormat:@"properties[%@]=%@", key, escapedValue]];
-  }
+@end
 
-  return parsedProperties;
+@implementation WTRUtilsTests
+
+- (void)testEscapeSpace {
+  XCTAssertEqualObjects(@"abc+def", [WTRUtils percentEscapeString:@"abc def"]);
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -47,7 +47,6 @@
 @property (nonatomic) int priority;
 
 - (NSMutableURLRequest *)requestWithURL:(NSURL *)url HTTPMethod:(NSString *)httpMethod andHTTPBody:(NSString *)httpBody;
-- (NSString *)percentEscapeString:(NSString *)string;
 - (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID;
 - (void)getEndUserWithEmail:(void (^)(NSInteger endUserID))endUserWithID;
 - (void)authenticate:(void (^)(void))authenticated;


### PR DESCRIPTION
Escape whitespaces in urls to prevent NSURL errors

## Changes

- Refactor code to move function to new WTRUtils
- Escape eligibility and pixel urls
- Add tests

## How to test

### Reproducing bug
1. Setup project as always
2. Use whitespaces for the end user email
```obj-c
[Wootric configureWithClientID:YOUR_CLIENT_ID accountToken:YOUR_ACCOUNT_TOKEN];
[Wootric setEndUserEmail:@"hello my friend"];
[Wootric setEndUserCreatedAt:@1234567890];
// Use only for testing
[Wootric forceSurvey:YES];
// show survey
[Wootric showSurveyInViewController:self];
```

3. Console should show an error message because the URL couldn't be created correctly

### Testing fix

1. Checkout this branch
2. Use whitespaces for the end user email
```obj-c
[Wootric configureWithClientID:YOUR_CLIENT_ID accountToken:YOUR_ACCOUNT_TOKEN];
[Wootric setEndUserEmail:@"hello my friend"];
[Wootric setEndUserCreatedAt:@1234567890];
// Use only for testing
[Wootric forceSurvey:YES];
// show survey
[Wootric showSurveyInViewController:self];
```

3. Everything should work normally

## Trello

https://trello.com/c/rnJZTv7P/4038-1-ios-fix-bad-urls-bug