### PR TITLE
PBS: add support for Property Based Sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.11.0 (2018-12-18)
+
+### Changes:
+
+- Add support for Property Based Sampling
+- Update eligibility logs to show more info
+
 ## 0.10.2 (2018-11-27)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.10.2"
+	pod "WootricSDK", "~> 0.11.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.10.2'
+  s.version  = '0.11.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.2</string>
+	<string>0.11.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRPropertiesParser.m
+++ b/WootricSDK/WootricSDK/WTRPropertiesParser.m
@@ -31,7 +31,8 @@
   NSString *parsedProperties = @"";
   for (NSString *key in dictionary) {
     NSString *escapedValue = [WTRUtils percentEscapeString:[NSString stringWithFormat:@"%@", [dictionary objectForKey:key]]];
-    parsedProperties = [NSString stringWithFormat:@"%@&%@", parsedProperties, [NSString stringWithFormat:@"properties[%@]=%@", key, escapedValue]];
+    NSString *escapedKey = [WTRUtils percentEscapeString:key];
+    parsedProperties = [NSString stringWithFormat:@"%@&%@", parsedProperties, [NSString stringWithFormat:@"properties[%@]=%@", escapedKey, escapedValue]];
   }
 
   return parsedProperties;

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -49,7 +49,7 @@
 @property (nonatomic, strong) NSNumber *externalCreatedAt;
 @property (nonatomic, strong) NSNumber *firstSurveyAfter;
 @property (nonatomic, strong) NSURL *facebookPage;
-@property (nonatomic, strong) NSDictionary *customProperties;
+@property (nonatomic, strong) NSMutableDictionary *customProperties;
 @property (nonatomic, assign) NSInteger surveyedDefaultDuration;
 @property (nonatomic, assign) NSInteger surveyedDefaultDurationDecline;
 @property (nonatomic, assign) NSInteger timeDelay;

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -115,7 +115,7 @@
 
 + (void)setEndUserProperties:(NSDictionary *)customProperties {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customProperties = customProperties;
+  apiClient.settings.customProperties = [NSMutableDictionary dictionaryWithDictionary:customProperties];
 }
 
 + (NSDictionary *)endUserProperties {

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -55,6 +55,7 @@
 - (NSString *)buildUniqueLinkAccountToken:(NSString *)accountToken endUserEmail:(NSString *)endUserEmail date:(NSTimeInterval)date randomString:(NSString *)randomString;
 - (NSString *)addSurveyServerCustomSettingsToURLString:(NSString *)baseURLString;
 - (NSString *)addVersionsToURLString:(NSString *)baseURLString;
+- (NSString *)addPropertiesToURLString:(NSString *)baseURLString;
 
 @end
 
@@ -225,6 +226,15 @@
   XCTAssertEqualObjects(versionString, @"string&os_name=iOS&os_version=10.0");
 }
 
+- (void)testAddPropertiesToURLString {
+  NSString *versionString = [_apiClient addPropertiesToURLString:@"string"];
+  XCTAssertEqualObjects(versionString, @"string");
+
+  _apiClient.settings.customProperties = [NSMutableDictionary dictionaryWithDictionary:@{ @"pricing_plan": @"pro plan" }];
+  versionString = [_apiClient addPropertiesToURLString:@"string"];
+  XCTAssertEqualObjects(versionString, @"string&properties[pricing_plan]=pro+plan");
+}
+
 - (void)testRandomStringLength {
   XCTAssertEqual([[_apiClient randomString] length], 16);
 }
@@ -270,7 +280,6 @@
   params = [_apiClient paramsWithScore:score endUserID:endUserID accountID:accountID uniqueLink:uniqueLink priority:priority text:text];
   XCTAssertEqualObjects(params, expectedResponseAccountIdText);
 }
-
 
 - (void)testDeclineParams {
   static NSString *expectedResponse = @"origin_url=com.wootric.WootricSDK-Demo&end_user[id]=12345678&survey[channel]=mobile&survey[unique_link]=5d8220d5b96ec1e0c4389a0a5951c05c3b1b998e53abbb11b14b9da5c2c0a81e&priority=0&metric_type=nps";


### PR DESCRIPTION
Add support for Property Based Sampling

## Changes:
- Update eligibility call to include properties
- Update eligibility's response log to show more information
- Update tests

## How to test

This can be tested in production since PBS is already live.

1. Enable PBS for the account you'll use to test this
2. Add a new property sampling rule via the UI
3. Setup SDK

```obj-c
- (void)viewDidLoad {
  [super viewDidLoad];
  NSString *clientID = @"YOUR_CLIENT_ID";
  NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
  
  [Wootric configureWithClientID:clientID accountToken:accountToken];
  [Wootric setEndUserEmail:@"pbs@test.com"];
  [Wootric setEndUserCreatedAt:@1234567890]; //use the timestamp depending on your sampling rule's settings  
  [Wootric setSurveyedDefault:NO]; // set this to NO if you don't want to set the "cookie"

  [Wootric setEndUserProperties:@{ @"your_property": @"value" }];

  [Wootric showSurveyInViewController:self];
}
```

4. In Xcode's console (⇧⌘Y) you can see the call to eligibility with the properties
5. After responding to the survey, you should see the new response with in the dashboard. You'll also see a new option inside Segments & Filters: 'Wootric Sampling Rule' click on it and the name of your rule will be in there.
 
## Trello
https://trello.com/c/bCFWiYRN/3964-add-pbs-to-mobile-sdks