### PR TITLE
Delegate callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.0 (2019-05-02)
+
+### Changes:
+
+- Add delegate pattern
+
 ## 0.11.1 (2019-03-21)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.11.1"
+	pod "WootricSDK", "~> 0.12.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.11.1'
+  s.version  = '0.12.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0F370D5921ACAAF10007C27A /* WTRUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F370D5721ACAAF10007C27A /* WTRUtils.h */; };
 		0F370D5A21ACAAF10007C27A /* WTRUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F370D5821ACAAF10007C27A /* WTRUtils.m */; };
+		0F8DE568226A2E6000A69F10 /* WTRSurveyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8DE567226A2E5F00A69F10 /* WTRSurveyDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F963EF720E14D5D001EE0D2 /* WTRNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */; };
 		0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */; };
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
@@ -21,6 +22,7 @@
 		0FE0F40920DC1AE000499248 /* WTRSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0F40820DC1AE000499248 /* WTRSurveyViewControllerTests.m */; };
 		0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */; };
 		0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */; };
+		0FF406B9227262B000C18075 /* WTRDelegateMockViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FF406B8227262B000C18075 /* WTRDelegateMockViewController.m */; };
 		178571982088FCA800CCBE02 /* WTRLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 178571962088FCA700CCBE02 /* WTRLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		178571992088FCA800CCBE02 /* WTRLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 178571972088FCA700CCBE02 /* WTRLogger.m */; };
 		1785719B2088FD1500CCBE02 /* WTRLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1785719A2088FD1500CCBE02 /* WTRLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -125,6 +127,7 @@
 		0F04153A1FA8F11000E3C926 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0F370D5721ACAAF10007C27A /* WTRUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRUtils.h; sourceTree = "<group>"; };
 		0F370D5821ACAAF10007C27A /* WTRUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtils.m; sourceTree = "<group>"; };
+		0F8DE567226A2E5F00A69F10 /* WTRSurveyDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRSurveyDelegate.h; sourceTree = "<group>"; };
 		0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRNotificationCenter.m; sourceTree = "<group>"; };
 		0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRiPADSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
@@ -138,6 +141,8 @@
 		0FE0F40820DC1AE000499248 /* WTRSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRApiClientTests.m; sourceTree = "<group>"; };
 		0FEC4B6C1D669E7300D7E941 /* WTRDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRDefaultsTests.m; sourceTree = "<group>"; };
+		0FF406B7227262B000C18075 /* WTRDelegateMockViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRDelegateMockViewController.h; sourceTree = "<group>"; };
+		0FF406B8227262B000C18075 /* WTRDelegateMockViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRDelegateMockViewController.m; sourceTree = "<group>"; };
 		178571962088FCA700CCBE02 /* WTRLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRLogger.h; sourceTree = "<group>"; };
 		178571972088FCA700CCBE02 /* WTRLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRLogger.m; sourceTree = "<group>"; };
 		1785719A2088FD1500CCBE02 /* WTRLogLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRLogLevel.h; sourceTree = "<group>"; };
@@ -262,6 +267,8 @@
 			children = (
 				0FE0F40120DC0D4800499248 /* WTRMockNotificationCenter.h */,
 				0FE0F40220DC0D4800499248 /* WTRMockNotificationCenter.m */,
+				0FF406B7227262B000C18075 /* WTRDelegateMockViewController.h */,
+				0FF406B8227262B000C18075 /* WTRDelegateMockViewController.m */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -466,6 +473,7 @@
 				B2D9FCDD1BF9F18E00479F9F /* SEGWootric.h */,
 				B2D9FCDE1BF9F18E00479F9F /* SEGWootric.m */,
 				B2DC6F051B81E6F900F599B3 /* Supporting Files */,
+				0F8DE567226A2E5F00A69F10 /* WTRSurveyDelegate.h */,
 			);
 			path = WootricSDK;
 			sourceTree = "<group>";
@@ -551,6 +559,7 @@
 				B2DC6F371B82143B00F599B3 /* WTRSettings.h in Headers */,
 				B25CE75F1BAADC920063E6E5 /* WTRQuestionView.h in Headers */,
 				B245509D1B909A03001AC1FB /* WTRSurveyViewController.h in Headers */,
+				0F8DE568226A2E6000A69F10 /* WTRSurveyDelegate.h in Headers */,
 				B27889701BDA5520001D5696 /* WTRiPADFeedbackView.h in Headers */,
 				B2BED80C1BA8610900DD1EFC /* WTRSingleScoreLabel.h in Headers */,
 				B27889751BDF85FD001D5696 /* UIItems.h in Headers */,
@@ -723,6 +732,7 @@
 				0FE0F40320DC0D4800499248 /* WTRMockNotificationCenter.m in Sources */,
 				0FC321FE21ADE4A0000E19DF /* WTRUtilsTests.m in Sources */,
 				0FEC4B6D1D669E7300D7E941 /* WTRDefaultsTests.m in Sources */,
+				0FF406B9227262B000C18075 /* WTRDelegateMockViewController.m in Sources */,
 				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
 				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.1</string>
+	<string>0.12.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -84,7 +84,7 @@
   if ([self feedbackTextPresent]) {
     return _feedbackTextView.text;
   }
-  return nil;
+  return @"";
 }
 
 - (BOOL)feedbackTextPresent {

--- a/WootricSDK/WootricSDK/WTRSurveyDelegate.h
+++ b/WootricSDK/WootricSDK/WTRSurveyDelegate.h
@@ -1,8 +1,8 @@
 //
-//  WootricSDK.h
+//  WTRSurveyDelegate.h
 //  WootricSDK
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+// Copyright (c) 2019 Wootric (https://wootric.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "Wootric.h"
-#import "SEGWootric.h"
-#import "WTRLogger.h"
-#import "WTRSurveyDelegate.h"
+@protocol WTRSurveyDelegate <NSObject>
 
-FOUNDATION_EXPORT double WootricSDKMainVersionNumber;
-FOUNDATION_EXPORT const unsigned char WootricSDKMainVersionString[];
+@required
+- (void)willPresentSurvey;
+- (void)didPresentSurvey;
+- (void)willHideSurvey;
+- (void)didHideSurvey:(NSDictionary *)data;
+
+@end

--- a/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
@@ -85,7 +85,7 @@
   if (_feedbackTextView.text) {
     return _feedbackTextView.text;
   }
-  return nil;
+  return @"";
 }
 
 - (BOOL)feedbackTextPresent {

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -287,4 +287,14 @@
  @discussion Notification posted when the survey view disappears, with userInfo as follows: `score` The NPS score as a NSNumber. `voted` Boolean NSNumber indicating whether the user voted or not.
  */
 + (NSNotificationName)surveyDidDisappearNotification;
+/**
+ @discussion Sets the delegate that receives notifications about SDK actions
+ @param delegate WTRSurveyDelegate to receive the notifications
+ */
++ (void)setDelegate:(id)delegate;
+/**
+ @discussion returns the delegate
+ */
++ (id)delegate;
+
 @end

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -30,8 +30,11 @@
 #import "WTRiPADSurveyViewController.h"
 #import "WTRApiClient.h"
 #import "WTRLogger.h"
+#import "WTRSurveyDelegate.h"
 
 #define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+
+static id<WTRSurveyDelegate> _delegate = nil;
 
 @implementation Wootric
 
@@ -154,7 +157,6 @@
         
       [WTRLogger log:@"presenting survey view"];
 
-      
       WTRApiClient *apiClient = [WTRApiClient sharedInstance];
       
       dispatch_async(dispatch_get_main_queue(), ^{
@@ -317,6 +319,16 @@
 
 + (NSNotificationName)surveyDidDisappearNotification {
   return @"com.wootric.surveyDidDisappearNotification";
+}
+
+#pragma mark - Delegate
+
++ (void)setDelegate:(id<WTRSurveyDelegate>)delegate {
+  _delegate = delegate;
+}
+
++ (id<WTRSurveyDelegate>)delegate {
+  return _delegate;
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/Mocks/WTRDelegateMockViewController.h
+++ b/WootricSDK/WootricSDKTests/Mocks/WTRDelegateMockViewController.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WTRDelegateMockViewController : UIViewController
+
+@property (nonatomic, assign) BOOL willPresentSurveyBool;
+@property (nonatomic, assign) BOOL didPresentSurveyBool;
+@property (nonatomic, assign) BOOL willHideSurveyBool;
+@property (nonatomic, assign) BOOL didHideSurveyBool;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WootricSDK/WootricSDKTests/Mocks/WTRDelegateMockViewController.m
+++ b/WootricSDK/WootricSDKTests/Mocks/WTRDelegateMockViewController.m
@@ -1,0 +1,25 @@
+#import "WTRDelegateMockViewController.h"
+#import "WTRSurveyDelegate.h"
+
+@interface WTRDelegateMockViewController () <WTRSurveyDelegate>
+@end
+
+@implementation WTRDelegateMockViewController
+
+- (void)willPresentSurvey {
+  _willPresentSurveyBool = YES;
+}
+
+- (void)didPresentSurvey {
+  _didPresentSurveyBool = YES;
+}
+
+- (void)willHideSurvey {
+  _willHideSurveyBool = YES;
+}
+
+- (void)didHideSurvey:(NSDictionary *)data {
+  _didHideSurveyBool = YES;
+}
+
+@end

--- a/WootricSDK/WootricSDKTests/iPad/WTRiPADSurveyViewControllerTests.m
+++ b/WootricSDK/WootricSDKTests/iPad/WTRiPADSurveyViewControllerTests.m
@@ -26,10 +26,13 @@
 #import "WTRiPADSurveyViewController.h"
 #import "WTRApiClient.h"
 #import "Wootric.h"
+#import "WTRSurveyDelegate.h"
+#import "WTRDelegateMockViewController.h"
 #import "WTRMockNotificationCenter.h"
 
 @interface WTRiPADSurveyViewControllerTests : XCTestCase
 @property (nonatomic, strong) WTRiPADSurveyViewController *viewController;
+@property (nonatomic, strong) WTRDelegateMockViewController *testViewController;
 @property (nonatomic, strong) WTRMockNotificationCenter *notificationCenter;
 @end
 
@@ -37,6 +40,8 @@
 
 - (void)setUp {
   [super setUp];
+  _testViewController = [[WTRDelegateMockViewController alloc] init];
+  [Wootric setDelegate:_testViewController];
   _notificationCenter = [WTRMockNotificationCenter new];
   _viewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:[WTRApiClient sharedInstance].settings
                                                              notificationCenter:_notificationCenter];
@@ -46,26 +51,31 @@
   [super tearDown];
   _notificationCenter = nil;
   _viewController = nil;
+  _testViewController = nil;
 }
 
 - (void)testViewWillAppear {
   [_viewController viewWillAppear:YES];
   XCTAssertEqual([Wootric surveyWillAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillAppearNotification'");
+  XCTAssertTrue(_testViewController.willPresentSurveyBool, @"willPresentSurvey callback not executed");
 }
 
 - (void)testViewWillDisappear {
   [_viewController viewWillDisappear:YES];
   XCTAssertEqual([Wootric surveyWillDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillDisappearNotification'");
+  XCTAssertTrue(_testViewController.willHideSurveyBool, @"willHideSurvey callback not executed");
 }
 
 - (void)testViewDidAppear {
   [_viewController viewDidAppear:YES];
   XCTAssertEqual([Wootric surveyDidAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidAppearNotification'");
+  XCTAssertTrue(_testViewController.didPresentSurveyBool, @"didPresentSurvey callback not executed");
 }
 
 - (void)testViewDidDisappear {
   [_viewController viewDidDisappear:YES];
   XCTAssertEqual([Wootric surveyDidDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidDisappearNotification'");
+  XCTAssertTrue(_testViewController.didHideSurveyBool, @"didHideSurvey callback not executed");
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/iPhone/WTRSurveyViewControllerTests.m
+++ b/WootricSDK/WootricSDKTests/iPhone/WTRSurveyViewControllerTests.m
@@ -26,10 +26,13 @@
 #import "WTRSurveyViewController.h"
 #import "WTRApiClient.h"
 #import "Wootric.h"
+#import "WTRSurveyDelegate.h"
+#import "WTRDelegateMockViewController.h"
 #import "WTRMockNotificationCenter.h"
 
 @interface WTRSurveyViewControllerTests : XCTestCase
 @property (nonatomic, strong) WTRSurveyViewController *viewController;
+@property (nonatomic, strong) WTRDelegateMockViewController *testViewController;
 @property (nonatomic, strong) WTRMockNotificationCenter *notificationCenter;
 @end
 
@@ -37,6 +40,9 @@
 
 - (void)setUp {
   [super setUp];
+  [Wootric configureWithClientID:@"id123" accountToken:@"nps-test"];
+  _testViewController = [[WTRDelegateMockViewController alloc] init];
+  [Wootric setDelegate:_testViewController];
   _notificationCenter = [WTRMockNotificationCenter new];
   _viewController = [[WTRSurveyViewController alloc] initWithSurveySettings:[WTRApiClient sharedInstance].settings
                                                          notificationCenter:_notificationCenter];
@@ -46,26 +52,31 @@
   [super tearDown];
   _notificationCenter = nil;
   _viewController = nil;
+  _testViewController = nil;
 }
 
 - (void)testViewWillAppear {
   [_viewController viewWillAppear:YES];
   XCTAssertEqual([Wootric surveyWillAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillAppearNotification'");
+  XCTAssertTrue(_testViewController.willPresentSurveyBool, @"willPresentSurvey callback not executed");
 }
 
 - (void)testViewWillDisappear {
   [_viewController viewWillDisappear:YES];
   XCTAssertEqual([Wootric surveyWillDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyWillDisappearNotification'");
+  XCTAssertTrue(_testViewController.willHideSurveyBool, @"willHideSurvey callback not executed");
 }
 
 - (void)testViewDidAppear {
   [_viewController viewDidAppear:YES];
   XCTAssertEqual([Wootric surveyDidAppearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidAppearNotification'");
+  XCTAssertTrue(_testViewController.didPresentSurveyBool, @"didPresentSurvey callback not executed");
 }
 
 - (void)testViewDidDisappear {
   [_viewController viewDidDisappear:YES];
   XCTAssertEqual([Wootric surveyDidDisappearNotification], _notificationCenter.notifications.firstObject, @"notification not equal to 'com.wootric.surveyDidDisappearNotification'");
+  XCTAssertTrue(_testViewController.didHideSurveyBool, @"didHideSurvey callback not executed");
 }
 
 @end


### PR DESCRIPTION
Add delegate pattert to receive callbacks from certaing events of the SDK.

## Changes
- Add WTRSurveyDelegate
- Update SurveyViewControllers for both iPhone & iPad
- Add delegate getter/setter to Wootric
- Update tests

## How to test
1. Make `ViewController` from `WootricSDK-Demo` conform to WTRSurveyDelegate

```obj_c
@interface ViewController () <WTRSurveyDelegate>

 @end
```

2. Set `ViewController` as the delegate

```obj_c
[Wootric setDelegate:self];
```

3. Add required methods to conform to the protocol

```obj_c
- (void)willPresentSurvey {
  NSLog(@"willPresentSurvey");
}

- (void)didPresentSurvey {
  NSLog(@"didPresentSurvey");
}

- (void)willHideSurvey {
  NSLog(@"willHideSurvey");
}

- (void)didHideSurvey:(NSDictionary *)data {
  NSLog(@"didHideSurvey");
  NSLog(@"%@", data);
}
```

4. Test in both iPhone & iPad

## Trello
https://trello.com/c/dZM7Wz45/4610-3-ios-sdk-callbacks-2