### PR TITLE
Add custom scale support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.13.0 (2019-06-21)
+
+### Changes:
+
+- Add support for custom scales
+
 ## 0.12.1 (2019-06-04)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.12.1"
+	pod "WootricSDK", "~> 0.13.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.12.1'
+  s.version  = '0.13.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.1</string>
+	<string>0.13.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -249,6 +249,7 @@ NSString *const WootricSamplingRule = @"Wootric Sampling Rule";
 - (void)authenticate:(void (^)(void))authenticated {
   NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/oauth/token", _baseAPIURL]];
   NSString *params = [NSString stringWithFormat:@"grant_type=client_credentials&client_id=%@", _clientID];
+  params = [self addVersionsToURLString:params];
   
   if (_clientSecret) {
     params = [params stringByAppendingFormat:@"&client_secret=%@", _clientSecret];
@@ -509,7 +510,7 @@ NSString *const WootricSamplingRule = @"Wootric Sampling Rule";
 }
 
 - (nullable NSString *)sdkVersion {
-  return [[NSBundle bundleForClass:[WTRApiClient class]] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  return [NSString stringWithFormat:@"ios-%@", [[NSBundle bundleForClass:[WTRApiClient class]] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]];
 }
 
 - (NSString *)osVersion {

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -79,8 +79,8 @@
         _surveyTypeScale = surveyTypeScaleFromSurvey;
         _scale = [self scoreRules][_surveyType][surveyTypeScaleFromSurvey];
       } else {
-        _surveyTypeScale = 0;
-        _scale = [self scoreRules][_surveyType][0];
+        _surveyTypeScale = _surveyTypeScale >= ((NSArray *)[self scoreRules][_surveyType]).count ? 0 : _surveyTypeScale;
+        _scale = [self scoreRules][_surveyType][_surveyTypeScale];
       }
     }
 
@@ -500,6 +500,10 @@
 
 - (void)setCustomTimeDelay:(NSInteger)customTimeDelay {
   _timeDelay = customTimeDelay < 0 ? 0 : customTimeDelay;
+}
+
+- (void)setCustomSurveyTypeScale:(NSInteger)customSurveyTypeScale {
+  _surveyTypeScale = customSurveyTypeScale < 0 ? 0 : customSurveyTypeScale;
 }
 
 - (BOOL)validEmailString {

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -267,6 +267,11 @@
  */
 + (void)setLogLevelVerbose;
 /**
+ @discussion Change the type of the scale for the survey type (not available for all types).
+ @param surveyTypeScale NSInteger representing the scale type.
+ */
++ (void)setSurveyTypeScale:(NSInteger)surveyTypeScale;
+/**
  @discussion If showOptOut is set to YES, it will show an option for the end user to opt out of being surveyed. Default value is NO.
  @param flag A boolean to show the opt out option.
  */

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -105,6 +105,11 @@ static id<WTRSurveyDelegate> _delegate = nil;
   apiClient.settings.forceSurvey = flag;
 }
 
++ (void)setSurveyTypeScale:(NSInteger)surveyTypeScale {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.settings.surveyTypeScale = surveyTypeScale;
+}
+
 + (void)showOptOut:(BOOL)flag {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.showOptOut = flag;

--- a/WootricSDK/WootricSDKTests/WTRSettingsTests.m
+++ b/WootricSDK/WootricSDKTests/WTRSettingsTests.m
@@ -42,7 +42,7 @@
 - (void)setUp {
   [super setUp];
   _settings = [[WTRSettings alloc] init];
-  [_settings parseDataFromSurveyServer:[self surveyServerSettings]];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"NPS"]];
 }
 
 - (void)tearDown {
@@ -320,7 +320,60 @@
   XCTAssertEqual(timeDelay, 10);
 }
 
-- (NSDictionary *)surveyServerSettings {
+- (void)testScoreRulesForNPS {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"NPS"]];
+  NSDictionary *scale = @{@"min": @0, @"max": @10, @"negative_type_max": @6, @"neutral_type_max": @8};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"NPS"]];
+  scale = @{@"min": @0, @"max": @10, @"negative_type_max": @6, @"neutral_type_max": @8};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:-1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"NPS"]];
+  scale = @{@"min": @0, @"max": @10, @"negative_type_max": @6, @"neutral_type_max": @8};
+  XCTAssertEqualObjects(scale, _settings.scale);
+}
+
+- (void)testScoreRulesForCES {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CES"]];
+  NSDictionary *scale = @{@"min": @1, @"max": @7, @"negative_type_max": @3, @"neutral_type_max": @5};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CES"]];
+  scale = @{@"min": @1, @"max": @7, @"negative_type_max": @3, @"neutral_type_max": @5};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:-1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CES"]];
+  scale = @{@"min": @1, @"max": @7, @"negative_type_max": @3, @"neutral_type_max": @5};
+  XCTAssertEqualObjects(scale, _settings.scale);
+}
+
+- (void)testScoreRulesForCSAT {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CSAT"]];
+  NSDictionary *scale = @{@"min": @1, @"max": @5, @"negative_type_max": @2, @"neutral_type_max": @3};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CSAT"]];
+  scale = @{@"min": @1, @"max": @10, @"negative_type_max": @6, @"neutral_type_max": @8};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:2];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CSAT"]];
+  scale = @{@"min": @1, @"max": @5, @"negative_type_max": @2, @"neutral_type_max": @3};
+  XCTAssertEqualObjects(scale, _settings.scale);
+
+  [_settings setSurveyTypeScale:-1];
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsForMode:@"CSAT"]];
+  scale = @{@"min": @1, @"max": @5, @"negative_type_max": @2, @"neutral_type_max": @3};
+  XCTAssertEqualObjects(scale, _settings.scale);
+}
+
+- (NSDictionary *)surveyServerSettingsForMode:(NSString *)mode {
   NSDictionary *settings = @{
     @"eligible": @1,
     @"settings": @{
@@ -328,6 +381,7 @@
       @"first_survey": @30,
       @"resurvey_throttle": @180,
       @"decline_resurvey_throttle": @30,
+      @"survey_type": mode,
       @"localized_texts": @{
         @"nps_question": @"How likely are you to recommend Wootric to a friend or co-worker?",
         @"anchors": @{
@@ -377,6 +431,7 @@
       @"first_survey": @30,
       @"resurvey_throttle": @180,
       @"decline_resurvey_throttle": @30,
+      @"survey_type": @"NPS",
       @"messages": @{
         @"followup_question": @"Can you explain why?",
         @"placeholder_text": @"Please, leave a feedback"


### PR DESCRIPTION
Add support for customer scales

## Changes
- Add `setSurveyTypeScale` method
- Update `sdk_version` string
- Add tests

## Test

1. Checkout this branch
2. Be sure to test with a `CSAT` account (the only mode that has custom scales)
3. Set the survey type scale
```obj-c
[Wootric setSurveyTypeScale:1];
```
4. Test for both iPhone & iPad
5. If wrong number is passed (e.g. -1, 4, 20) it should return default scale for that mode.
6. Check that `sdk_version` has following format: `ios-X.Y.Z`

**Internal Trello Ref:** [link](https://trello.com/c/zXMeXMPd/4968-ios-sdk-customcsat-scale)
