### PR TITLE
Add skipFeedbackScreen method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.14.0 (2019-08-12)
+
+### Changes:
+
+- Add skipFeedbackScreen method
+- Fix promoter bug for non NPS scales
+
 ## 0.13.0 (2019-06-21)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.13.0"
+	pod "WootricSDK", "~> 0.14.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.13.0'
+  s.version  = '0.13.1'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */; };
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
 		0FC321FE21ADE4A0000E19DF /* WTRUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */; };
+		0FC7D23122F9E98200C170AF /* WTRWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC7D23022F9E98200C170AF /* WTRWootricTests.m */; };
 		0FD5920F1D99EB0500DD173B /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */; };
 		0FE0F3F920DC041B00499248 /* WTRNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */; };
 		0FE0F3FD20DC059700499248 /* WTRDefaultNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */; };
@@ -130,6 +131,7 @@
 		0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRiPADSurveyViewControllerTests.m; sourceTree = "<group>"; };
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
 		0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtilsTests.m; sourceTree = "<group>"; };
+		0FC7D23022F9E98200C170AF /* WTRWootricTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRWootricTests.m; sourceTree = "<group>"; };
 		0FD5920E1D99EAFF00DD173B /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
 		0FE0F3F720DC041B00499248 /* WTRNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRNotificationCenter.h; sourceTree = "<group>"; };
 		0FE0F3FB20DC059700499248 /* WTRDefaultNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRDefaultNotificationCenter.h; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				B2DC6F121B81E6F900F599B3 /* Supporting Files */,
 				0FE2FAC71CE4356F0065823C /* WTRApiClientTests.m */,
 				0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */,
+				0FC7D23022F9E98200C170AF /* WTRWootricTests.m */,
 			);
 			path = WootricSDKTests;
 			sourceTree = "<group>";
@@ -727,6 +730,7 @@
 				0FF406B9227262B000C18075 /* WTRDelegateMockViewController.m in Sources */,
 				0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */,
 				B21372961BED0DB1009F5974 /* WTRSurveyTests.m in Sources */,
+				0FC7D23122F9E98200C170AF /* WTRWootricTests.m in Sources */,
 				0FE2FAC81CE4356F0065823C /* WTRApiClientTests.m in Sources */,
 				0FE0F40920DC1AE000499248 /* WTRSurveyViewControllerTests.m in Sources */,
 			);

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0</string>
+	<string>0.14.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/SEGWootric.h
+++ b/WootricSDK/WootricSDK/SEGWootric.h
@@ -61,6 +61,7 @@
 - (void)surveyImmediately:(BOOL)flag;
 - (void)forceSurvey:(BOOL)flag;
 - (void)skipFeedbackScreenForPromoter:(BOOL)flag;
+- (void)skipFeedbackScreen:(BOOL)flag;
 - (void)passScoreAndTextToURL:(BOOL)flag;
 
 - (void)setFacebookPage:(NSURL *)facebookPage;

--- a/WootricSDK/WootricSDK/SEGWootric.m
+++ b/WootricSDK/WootricSDK/SEGWootric.m
@@ -99,6 +99,10 @@
   [Wootric skipFeedbackScreenForPromoter:flag];
 }
 
+- (void)skipFeedbackScreen:(BOOL)flag {
+  [Wootric skipFeedbackScreen:flag];
+}
+
 - (void)passScoreAndTextToURL:(BOOL)flag {
   [Wootric passScoreAndTextToURL:flag];
 }

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -58,6 +58,7 @@
 @property (nonatomic, assign) BOOL showOptOut;
 @property (nonatomic, assign) BOOL setDefaultAfterSurvey;
 @property (nonatomic, assign) BOOL skipFeedbackScreen;
+@property (nonatomic, assign) BOOL skipFeedbackScreenForPromoter;
 @property (nonatomic, assign) BOOL passScoreAndTextToURL;
 @property (nonatomic, strong) UIColor *sendButtonBackgroundColor;
 @property (nonatomic, strong) UIColor *sliderColor;
@@ -66,6 +67,9 @@
 - (void)parseDataFromSurveyServer:(NSDictionary *)surveyServerSettings;
 - (int)maximumScore;
 - (int)minimumScore;
+- (BOOL)negativeTypeScore:(int)score;
+- (BOOL)neutralTypeScore:(int)score;
+- (BOOL)positiveTypeScore:(int)score;
 - (NSDictionary *)scoreRules;
 - (NSString *)getEndUserEmailOrUnknown;
 

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -164,8 +164,10 @@
     [_feedbackView textViewResignFirstResponder];
     [self presentShareScreenOrDismissForScore:_currentScore];
   } else {
-    if (_settings.skipFeedbackScreen && _currentScore >= 9) {
+    if (_settings.skipFeedbackScreen) {
       [self presentShareScreenOrDismissForScore:_currentScore];
+    } else if (_settings.skipFeedbackScreenForPromoter && [_settings positiveTypeScore:_currentScore]) {
+        [self presentShareScreenOrDismissForScore:_currentScore];
     } else {
       [self setQuestionViewVisible:NO andFeedbackViewVisible:YES];
       [_feedbackView setFollowupLabelTextBasedOnScore:_currentScore];
@@ -284,8 +286,8 @@
 }
 
 - (void)setupFacebookAndTwitterForScore:(int)score {
-  BOOL twitterAvailable = ([self twitterHandlerAndFeedbackTextPresent] && score >= 9);
-  BOOL facebookAvailable = ([_settings facebookPageSet] && score >= 9);
+  BOOL twitterAvailable = ([self twitterHandlerAndFeedbackTextPresent] && [_settings positiveTypeScore:score]);
+  BOOL facebookAvailable = ([_settings facebookPageSet] && [_settings positiveTypeScore:score]);
   if (!twitterAvailable && !facebookAvailable) {
     _constraintModalHeight.constant = 230;
     _socialShareViewHeightConstraint.constant = 190;
@@ -299,8 +301,8 @@
 
 - (BOOL)socialShareAvailableForScore:(int)score {
   return ([_settings thankYouLinkConfiguredForScore:score] ||
-          ([self twitterHandlerAndFeedbackTextPresent] && score >= 9) ||
-          ([_settings facebookPageSet] && score >= 9));
+          ([self twitterHandlerAndFeedbackTextPresent] && [_settings positiveTypeScore:score]) ||
+          ([_settings facebookPageSet] && [_settings positiveTypeScore:score]));
 }
 
 - (BOOL)twitterHandlerAndFeedbackTextPresent {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -134,7 +134,9 @@
   [_feedbackView setFollowupLabelTextBasedOnScore:sender.assignedScore];
   [_feedbackView setFeedbackPlaceholderText:placeholderText];
   if (_feedbackView.hidden) {
-    if (_settings.skipFeedbackScreen && _currentScore >= 9) {
+    if (_settings.skipFeedbackScreen) {
+      [self sendButtonPressed];
+    } else if (_settings.skipFeedbackScreenForPromoter && [_settings positiveTypeScore:_currentScore]) {
       [self sendButtonPressed];
     } else {
       [self showFeedbackView];
@@ -276,8 +278,8 @@
 }
 
 - (void)setupFacebookAndTwitterForScore:(int)score {
-  BOOL twitterAvailable = ([self twitterHandlerAndFeedbackTextPresent] && score >= 9);
-  BOOL facebookAvailable = ([_settings facebookPageSet] && score >= 9);
+  BOOL twitterAvailable = ([self twitterHandlerAndFeedbackTextPresent] && [_settings positiveTypeScore:score]);
+  BOOL facebookAvailable = ([_settings facebookPageSet] && [_settings positiveTypeScore:score]);
   if (![_settings thankYouLinkConfiguredForScore:score]) {
     [_socialShareView noThankYouButton];
   }
@@ -287,8 +289,8 @@
 
 - (BOOL)socialShareAvailableForScore:(int)score {
   return ([_settings thankYouLinkConfiguredForScore:score] ||
-          ([self twitterHandlerAndFeedbackTextPresent] && score >= 9) ||
-          ([_settings facebookPageSet] && score >= 9));
+          ([self twitterHandlerAndFeedbackTextPresent] && [_settings positiveTypeScore:score]) ||
+          ([_settings facebookPageSet] && [_settings positiveTypeScore:score]));
 }
 
 - (BOOL)twitterHandlerAndFeedbackTextPresent {

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -142,6 +142,11 @@
 */
 + (void)skipFeedbackScreenForPromoter:(BOOL)flag;
 /**
+ @discussion With this option enabled, the open feedback screen will be skipped and go directly to the thank you message.
+ @param flag A boolean to set if the feedback screen should be skipped.
+ */
++ (void)skipFeedbackScreen:(BOOL)flag;
+/**
  @discussion If you enable this setting, score and feedback text will be added as wootric_score and wootric_text params to the "thank you" URL you have provided. (Check "Custom Thank You" section)
  @see setThankYouMessage
  @param flag A boolean to set if the score and text should be passed to the custom "thank you" URL

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -142,6 +142,11 @@ static id<WTRSurveyDelegate> _delegate = nil;
 
 + (void)skipFeedbackScreenForPromoter:(BOOL)flag {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.settings.skipFeedbackScreenForPromoter = flag;
+}
+
++ (void)skipFeedbackScreen:(BOOL)flag {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.skipFeedbackScreen = flag;
 }
 

--- a/WootricSDK/WootricSDKTests/WTRWootricTests.m
+++ b/WootricSDK/WootricSDKTests/WTRWootricTests.m
@@ -1,270 +1,178 @@
 //
-//  SEGWootricTests.m
+//  WTRWootricTests.m
 //  WootricSDKTests
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+//  Created by Admin on 8/6/19.
+//  Copyright © 2019 Wootric. All rights reserved.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
+#import <WootricSDK/WootricSDK.h>
 #import "WTRApiClient.h"
-#import "SEGWootric.h"
 
-@interface SEGWootricTests : XCTestCase
+@interface WTRWootricTests : XCTestCase
 
 @property (nonatomic, strong) WTRApiClient *apiClient;
-@property (nonatomic, strong) SEGWootric *segWootric;
 @property (nonatomic, strong) UIColor *color;
 
 @end
 
-@implementation SEGWootricTests
+@implementation WTRWootricTests
 
 - (void)setUp {
-  [super setUp];
+  [Wootric configureWithClientID:@"NPS-abc123" accountToken:@"abcdefg12345677"];
   _apiClient = [WTRApiClient sharedInstance];
-  _segWootric = [[SEGWootric alloc] init];
   _color = [UIColor colorWithRed:0.1f green:0.2f blue:0.3f alpha:1.0f];
-}
-
-- (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the class.
-  [super tearDown];
-}
-
-- (void)testConfiguration {
-  static NSString *clientId = @"testClientID";
-  static NSString *clientSecret = @"testClientSecret";
-  static NSString *accountToken = @"NP-Token";
-  [_segWootric configureWithClientID:clientId clientSecret:clientSecret accountToken:accountToken];
-  
-  XCTAssertEqualObjects(_apiClient.clientID, clientId, @"clientID should be equal to testClientID");
-  XCTAssertEqualObjects(_apiClient.clientSecret, clientSecret, @"clientSecret should be equal to testClientSecret");
-  XCTAssertEqualObjects(_apiClient.accountToken, accountToken, @"accountToken should be equal to NP-Token");
-  
-  _apiClient.clientID = nil;
-  _apiClient.clientSecret = nil;
-  _apiClient.accountToken = nil;
 }
 
 - (void)testSetEndUserCreatedAt {
   NSNumber *endUserCreatedAt = @123;
-  [_segWootric setEndUserCreatedAt:endUserCreatedAt];
+  [Wootric setEndUserCreatedAt:endUserCreatedAt];
   
   XCTAssertEqualObjects(_apiClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
-  
-  _apiClient.settings.externalCreatedAt = nil;
 }
 
 - (void)testSetEndUserEmail {
   static NSString *endUserEmail = @"test@example.com";
-  [_segWootric setEndUserEmail:endUserEmail];
+  [Wootric setEndUserEmail:endUserEmail];
   
   XCTAssertEqualObjects(_apiClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
-  
-  _apiClient.settings.endUserEmail = nil;
 }
 
 - (void)testSetProductNameForEndUser {
   static NSString *productName = @"Example";
-  [_segWootric setProductNameForEndUser:@"Example"];
+  [Wootric setProductNameForEndUser:@"Example"];
   
   XCTAssertEqualObjects(_apiClient.settings.productName, productName, @"productName should be equal to Example");
-  
-  _apiClient.settings.productName = nil;
 }
 
 - (void)testSetCustomLanguage {
   static NSString *language = @"Epañol";
-  [_segWootric setCustomLanguage:language];
+  [Wootric setCustomLanguage:language];
   
   XCTAssertEqualObjects(_apiClient.settings.languageCode, language, @"languageCode should be equal to Español");
-  
-  _apiClient.settings.languageCode = nil;
 }
 
 - (void)testSetCustomAudience {
   static NSString *audience = @"Custom audience";
-  [_segWootric setCustomAudience:audience];
+  [Wootric setCustomAudience:audience];
   
   XCTAssertEqualObjects(_apiClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
-  
-  _apiClient.settings.customAudience = nil;
 }
 
 - (void)testSetCustomProductName {
   static NSString *customProductName = @"Custom product";
-  [_segWootric setCustomProductName:customProductName];
+  [Wootric setCustomProductName:customProductName];
   
   XCTAssertEqualObjects(_apiClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
-  
-  _apiClient.settings.customProductName = nil;
 }
 
 - (void)testSetCustomFinalThankYou {
   static NSString *customFinalThankYou = @"CustomFinalThankYou";
-  [_segWootric setCustomFinalThankYou:customFinalThankYou];
-  
+  [Wootric setCustomFinalThankYou:customFinalThankYou];
   XCTAssertEqualObjects(_apiClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
-  
-  _apiClient.settings.customFinalThankYou = nil;
 }
 
 - (void)testSetCustomQuestion {
   static NSString *customQuestion = @"Would you recommend this to a friend?";
-  [_segWootric setCustomQuestion:customQuestion];
+  [Wootric setCustomQuestion:customQuestion];
   
   XCTAssertEqualObjects(_apiClient.settings.customQuestion, customQuestion, @"customQuestion should be equal to Would you recommend this to a friend?");
-  
-  _apiClient.settings.customQuestion = nil;
 }
 
 - (void)testSetEndUserProperties {
   NSDictionary *endUserProperties = @{@"email": @"test@example.com"};
-  [_segWootric setEndUserProperties:endUserProperties];
-
+  [Wootric setEndUserProperties:endUserProperties];
+  
   XCTAssertEqualObjects(_apiClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
-  
   XCTAssertEqualObjects([_apiClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
-  
-  _apiClient.settings.customProperties = nil;
-  
 }
 
 - (void)testSetFirstSurveyAfter {
   XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
-  
-  [_segWootric setFirstSurveyAfter:@15];
-  
+  [Wootric setFirstSurveyAfter:@15];
   XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
-  
-  _apiClient.settings.firstSurveyAfter = nil;
-  
 }
 
 - (void)testSetSurveyedDefault {
   XCTAssertTrue(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
-  
-  [_segWootric setSurveyedDefault:NO];
-
+  [Wootric setSurveyedDefault:NO];
   XCTAssertFalse(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
-  
-  _apiClient.settings.setDefaultAfterSurvey = YES;
 }
 
 - (void)testSurveyImmediately {
-  [_segWootric surveyImmediately:YES];
-  
+  [Wootric surveyImmediately:YES];
   XCTAssertTrue(_apiClient.settings.surveyImmediately, @"surveyImmediately should be true");
-  
-  [_segWootric surveyImmediately:NO];
-  
+  [Wootric surveyImmediately:NO];
   XCTAssertFalse(_apiClient.settings.surveyImmediately, @"surveyImmediately should be false");
 }
 
 - (void)testForceSurvey {
-  [_segWootric forceSurvey:YES];
+  [Wootric forceSurvey:YES];
   
   XCTAssertTrue(_apiClient.settings.forceSurvey, @"forceSurvey should be true");
-  
-  _apiClient.settings.forceSurvey = NO;
 }
 
 - (void)testSkipFeedbackScreenForPromoter {
-  [_segWootric skipFeedbackScreenForPromoter:NO];
+  [Wootric skipFeedbackScreenForPromoter:NO];
   XCTAssertFalse(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be false");
-  [_segWootric skipFeedbackScreenForPromoter:YES];
+  [Wootric skipFeedbackScreenForPromoter:YES];
   XCTAssertTrue(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be true");
-  _apiClient.settings.skipFeedbackScreenForPromoter = NO;
 }
 
 - (void)testSkipFeedbackScreen {
-  [_segWootric skipFeedbackScreen:NO];
+  [Wootric skipFeedbackScreen:NO];
   XCTAssertFalse(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
-  [_segWootric skipFeedbackScreen:YES];
+  [Wootric skipFeedbackScreen:YES];
   XCTAssertTrue(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
-  _apiClient.settings.skipFeedbackScreen = NO;
 }
 
 - (void)testPassScoreAndTextToURL {
-  [_segWootric passScoreAndTextToURL:NO];
+  [Wootric passScoreAndTextToURL:NO];
   
   XCTAssertFalse(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
   
-  [_segWootric passScoreAndTextToURL:YES];
+  [Wootric passScoreAndTextToURL:YES];
   
   XCTAssertTrue(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
-  
-  _apiClient.settings.passScoreAndTextToURL = NO;
 }
 
 - (void)testSetFacebookPage {
   NSURL *url = [NSURL URLWithString:@"facebook.com/test"];
-  [_segWootric setFacebookPage:url];
+  [Wootric setFacebookPage:url];
   
   XCTAssertEqualObjects(_apiClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
-  
-  _apiClient.settings.facebookPage = nil;
 }
 
 - (void)testSetTwitterHandler {
   static NSString *twitterHandler = @"twitter";
-  [_segWootric setTwitterHandler:twitterHandler];
+  [Wootric setTwitterHandler:twitterHandler];
   
   XCTAssertEqualObjects(_apiClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
-  
-  _apiClient.settings.twitterHandler = nil;
-  
 }
 
 - (void)testSetSendButtonBackgroundColor {
-  [_segWootric setSendButtonBackgroundColor:_color];
+  [Wootric setSendButtonBackgroundColor:_color];
   
   XCTAssertEqualObjects(_apiClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
-  
-  _apiClient.settings.sendButtonBackgroundColor = nil;
 }
 
 - (void)testSetSliderColor {
-  [_segWootric setSliderColor:_color];
+  [Wootric setSliderColor:_color];
   
   XCTAssertEqualObjects(_apiClient.settings.sliderColor, _color, @"sliderColor should equal to color");
-  
-  _apiClient.settings.sliderColor = nil;
 }
 
 - (void)testSetThankYouButtonBackgroundColor {
-  
-  [_segWootric setThankYouButtonBackgroundColor:_color];
+  [Wootric setThankYouButtonBackgroundColor:_color];
   
   XCTAssertEqualObjects(_apiClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
-  
-  _apiClient.settings.thankYouButtonBackgroundColor = nil;
 }
 
 - (void)testSetSocialSharingColor {
-  
-  [_segWootric setSocialSharingColor:_color];
+  [Wootric setSocialSharingColor:_color];
   
   XCTAssertEqualObjects(_apiClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
-  
-  _apiClient.settings.socialSharingColor = nil;
 }
 
 - (void)testShowOptOutDefaultNo {
@@ -272,10 +180,9 @@
 }
 
 - (void)testSetShowOptOut {
-  [_segWootric showOptOut:YES];
-
+  [Wootric showOptOut:YES];
+  
   XCTAssertTrue(_apiClient.settings.showOptOut, @"showOptOut default value should be YES");
-
   _apiClient.settings.showOptOut = NO;
 }
 


### PR DESCRIPTION
## Changes

- Add skipFeedbackScreen method
- Fix promoter bug for non NPS scales
- Add tests

## Test

1. Set `[Wootric skipFeedbackScreen:YES];`
2. Feedback screen should be skipped regardless of the score.
3. Test on both smartphones and tablets

## Trello (internal reference)

https://trello.com/c/ISAU3huz/5194-ios-sdk-add-skipfeedbackscreen-method