### PR TITLE
Third screen settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.15.0 (2019-10-18)
+
+### Changes:
+
+- Add button to Demo project to start the survey
+- Add support of admin panel values for 3rd screen
+
 ## 0.14.0 (2019-08-12)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.14.0"
+	pod "WootricSDK", "~> 0.15.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK-Demo/WootricSDK-Demo.xcodeproj/project.pbxproj
+++ b/WootricSDK-Demo/WootricSDK-Demo.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 		B2DC6EC71B81E5D800F599B3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Wootric;
 				TargetAttributes = {
 					B2DC6ECE1B81E5D800F599B3 = {
@@ -236,7 +236,7 @@
 			};
 			buildConfigurationList = B2DC6ECA1B81E5D800F599B3 /* Build configuration list for PBXProject "WootricSDK-Demo" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -354,6 +354,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -409,6 +410,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/WootricSDK-Demo/WootricSDK-Demo/Base.lproj/Main.storyboard
+++ b/WootricSDK-Demo/WootricSDK-Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,22 +18,36 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_wootric" translatesAutoresizingMaskIntoConstraints="NO" id="QaC-Tw-8Dg">
-                                <rect key="frame" x="210" y="28" width="180" height="180"/>
+                                <rect key="frame" x="97.5" y="28" width="180" height="180"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="180" id="2Ek-as-J8b"/>
                                     <constraint firstAttribute="width" constant="180" id="TQN-JQ-i6u"/>
                                     <constraint firstAttribute="height" constant="180" id="XYX-SS-cwO"/>
                                 </constraints>
                             </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="etm-Ev-Oyk">
+                                <rect key="frame" x="92" y="216" width="191" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="1VL-Vx-6NC"/>
+                                </constraints>
+                                <state key="normal" title="MANUALLY START SURVEY">
+                                    <color key="titleColor" red="0.37876600027084351" green="0.52763652801513672" blue="0.23737165331840515" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="startSurvey:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LR6-SZ-E0s"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="QaC-Tw-8Dg" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="8r3-eQ-HOv"/>
                             <constraint firstItem="QaC-Tw-8Dg" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" symbolic="YES" id="G6u-vx-psm"/>
+                            <constraint firstItem="etm-Ev-Oyk" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerXWithinMargins" id="PoX-dq-Vtv"/>
+                            <constraint firstItem="etm-Ev-Oyk" firstAttribute="top" secondItem="QaC-Tw-8Dg" secondAttribute="bottom" constant="8" symbolic="YES" id="Q0X-E3-7Z4"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
+++ b/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
@@ -33,15 +33,19 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [self startSurvey:nil];
+}
+
+- (IBAction)startSurvey:(UIButton *)sender {
   NSString *clientID = @"YOUR_CLIENT_ID";
   NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
-  
+
   [Wootric configureWithClientID:clientID accountToken:accountToken];
   [Wootric setEndUserEmail:@"END_USER_EMAIL"];
   [Wootric setEndUserCreatedAt:@1234567890];
-  
+
   [Wootric forceSurvey:YES];
-  
+
   [Wootric showSurveyInViewController:self];
 }
 

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.14.0'
+  s.version  = '0.15.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -7,11 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F23A96A227A4C000093765A /* WTRUserCustomThankYou.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F23A968227A4C000093765A /* WTRUserCustomThankYou.h */; };
+		0F23A96B227A4C000093765A /* WTRUserCustomThankYou.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F23A969227A4C000093765A /* WTRUserCustomThankYou.m */; };
 		0F370D5921ACAAF10007C27A /* WTRUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F370D5721ACAAF10007C27A /* WTRUtils.h */; };
 		0F370D5A21ACAAF10007C27A /* WTRUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F370D5821ACAAF10007C27A /* WTRUtils.m */; };
 		0F8DE568226A2E6000A69F10 /* WTRSurveyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8DE567226A2E5F00A69F10 /* WTRSurveyDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F963EF720E14D5D001EE0D2 /* WTRNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */; };
 		0F963EF920E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */; };
+		0FA645112289E475008A1C00 /* WTRCustomSocial.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA6450F2289E475008A1C00 /* WTRCustomSocial.h */; };
+		0FA645122289E475008A1C00 /* WTRCustomSocial.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA645102289E475008A1C00 /* WTRCustomSocial.m */; };
 		0FAB0CAB1CFE1DCE00977346 /* SEGWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */; };
 		0FC321FE21ADE4A0000E19DF /* WTRUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */; };
 		0FC7D23122F9E98200C170AF /* WTRWootricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC7D23022F9E98200C170AF /* WTRWootricTests.m */; };
@@ -124,11 +128,15 @@
 
 /* Begin PBXFileReference section */
 		0F04153A1FA8F11000E3C926 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0F23A968227A4C000093765A /* WTRUserCustomThankYou.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRUserCustomThankYou.h; sourceTree = "<group>"; };
+		0F23A969227A4C000093765A /* WTRUserCustomThankYou.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUserCustomThankYou.m; sourceTree = "<group>"; };
 		0F370D5721ACAAF10007C27A /* WTRUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRUtils.h; sourceTree = "<group>"; };
 		0F370D5821ACAAF10007C27A /* WTRUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtils.m; sourceTree = "<group>"; };
 		0F8DE567226A2E5F00A69F10 /* WTRSurveyDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRSurveyDelegate.h; sourceTree = "<group>"; };
 		0F963EF620E14D5D001EE0D2 /* WTRNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRNotificationCenter.m; sourceTree = "<group>"; };
 		0F963EF820E156E6001EE0D2 /* WTRiPADSurveyViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRiPADSurveyViewControllerTests.m; sourceTree = "<group>"; };
+		0FA6450F2289E475008A1C00 /* WTRCustomSocial.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTRCustomSocial.h; sourceTree = "<group>"; };
+		0FA645102289E475008A1C00 /* WTRCustomSocial.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRCustomSocial.m; sourceTree = "<group>"; };
 		0FAB0CAA1CFE1DCE00977346 /* SEGWootricTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGWootricTests.m; sourceTree = "<group>"; };
 		0FC321FD21ADE4A0000E19DF /* WTRUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRUtilsTests.m; sourceTree = "<group>"; };
 		0FC7D23022F9E98200C170AF /* WTRWootricTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTRWootricTests.m; sourceTree = "<group>"; };
@@ -393,6 +401,10 @@
 				B22976741BB1404D00FC2772 /* WTRCustomThankYou.m */,
 				B23DEF791BBBE9CA002A7FFD /* WTRUserCustomMessages.h */,
 				B23DEF7A1BBBE9CA002A7FFD /* WTRUserCustomMessages.m */,
+				0F23A968227A4C000093765A /* WTRUserCustomThankYou.h */,
+				0F23A969227A4C000093765A /* WTRUserCustomThankYou.m */,
+				0FA6450F2289E475008A1C00 /* WTRCustomSocial.h */,
+				0FA645102289E475008A1C00 /* WTRCustomSocial.m */,
 			);
 			name = SurveySettings;
 			sourceTree = "<group>";
@@ -525,6 +537,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0FA645112289E475008A1C00 /* WTRCustomSocial.h in Headers */,
 				B2C940681BA71A2900482494 /* WTRSliderDot.h in Headers */,
 				B2DC6F2E1B82000900F599B3 /* Wootric.h in Headers */,
 				B2D9FCDF1BF9F18E00479F9F /* SEGWootric.h in Headers */,
@@ -571,6 +584,7 @@
 				B29A2E881BAC0B50007181D3 /* WTRFeedbackView.h in Headers */,
 				B2DC6F331B820E6B00F599B3 /* WTRApiClient.h in Headers */,
 				B2C940601BA300A000482494 /* WTRSlider.h in Headers */,
+				0F23A96A227A4C000093765A /* WTRUserCustomThankYou.h in Headers */,
 				B278896D1BD914F2001D5696 /* SimpleConstraints.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -620,7 +634,7 @@
 		B2DC6EF91B81E6F900F599B3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Wootric;
 				TargetAttributes = {
 					B2DC6F011B81E6F900F599B3 = {
@@ -636,6 +650,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = B2DC6EF81B81E6F900F599B3;
@@ -705,12 +720,14 @@
 				B24550A21B909A49001AC1FB /* WTRSurveyViewController+Views.m in Sources */,
 				B23DEF7C1BBBE9CA002A7FFD /* WTRUserCustomMessages.m in Sources */,
 				B25CE7601BAADC920063E6E5 /* WTRQuestionView.m in Sources */,
+				0FA645122289E475008A1C00 /* WTRCustomSocial.m in Sources */,
 				B2BED80D1BA8610900DD1EFC /* WTRSingleScoreLabel.m in Sources */,
 				B29A2E891BAC0B50007181D3 /* WTRFeedbackView.m in Sources */,
 				B268667F1BD63B7000A4288D /* WTRCircleScoreButton.m in Sources */,
 				B2DC6F341B820E6B00F599B3 /* WTRApiClient.m in Sources */,
 				B24550921B8E0188001AC1FB /* WTRColor.m in Sources */,
 				B2102A2E1BB59ABC0025DABC /* WTRDefaults.m in Sources */,
+				0F23A96B227A4C000093765A /* WTRUserCustomThankYou.m in Sources */,
 				B2DC6F381B82143B00F599B3 /* WTRSettings.m in Sources */,
 				B260ECE21BD8D7E300E29CD5 /* NSLayoutConstraint+Simple.m in Sources */,
 				B229767E1BB1901500FC2772 /* WTRThankYouButton.m in Sources */,
@@ -751,6 +768,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -809,6 +827,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/WootricSDK/WootricSDK.xcodeproj/xcshareddata/xcschemes/WootricSDK.xcscheme
+++ b/WootricSDK/WootricSDK.xcodeproj/xcshareddata/xcschemes/WootricSDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.14.0</string>
+	<string>0.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.h
+++ b/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.h
@@ -34,6 +34,7 @@
 - (NSLayoutConstraint *)toSecondViewCenterX:(UIView *)secondView;
 - (NSLayoutConstraint *)toSecondViewCenterY:(UIView *)secondView;
 - (void)addToView:(UIView *)view;
+- (void)removeFromView:(UIView *)view;
 - (void)addConstraint;
 
 @end

--- a/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.m
+++ b/WootricSDK/WootricSDK/NSLayoutConstraint+Simple.m
@@ -30,6 +30,10 @@
   [view addConstraint:self];
 }
 
+- (void)removeFromView:(UIView *)view {
+  [view removeConstraint:self];
+}
+
 - (NSLayoutConstraint *)withConstant:(CGFloat)constant {
   NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.firstItem
                                                                 attribute:self.firstAttribute

--- a/WootricSDK/WootricSDK/UIItems.h
+++ b/WootricSDK/WootricSDK/UIItems.h
@@ -27,13 +27,13 @@
 
 @interface UIItems : NSObject
 
-+ (UILabel *)likelyAnchorWithSettings:(WTRSettings *)settings andFont:(UIFont *)font;
-+ (UILabel *)notLikelyAnchorWithSettings:(WTRSettings *)settings andFont:(UIFont *)font;
++ (UILabel *)likelyAnchorWithSettings:(WTRSettings *)settings font:(UIFont *)font;
++ (UILabel *)notLikelyAnchorWithSettings:(WTRSettings *)settings font:(UIFont *)font;
 + (UILabel *)followupLabelWithTextColor:(UIColor *)textColor;
 + (UILabel *)feedbackPlaceholder;
-+ (UILabel *)questionLabelWithSettings:(WTRSettings *)settings andFont:(UIFont *)font;
-+ (UILabel *)finalThankYouLabelWithSettings:(WTRSettings *)settings textColor:(UIColor *)textColor andFont:(UIFont *)font;
-+ (UILabel *)customThankYouLabelWithFont:(UIFont *)font;
++ (UILabel *)questionLabelWithSettings:(WTRSettings *)settings font:(UIFont *)font;
++ (UILabel *)thankYouMainLabelWithSettings:(WTRSettings *)settings textColor:(UIColor *)textColor font:(UIFont *)font;
++ (UILabel *)thankYouSetupLabelWithFont:(UIFont *)font;
 + (UIButton *)socialButtonWithTargetViewController:(UIViewController *)viewController title:(NSString *)title textColor:(UIColor *)textColor;
 + (UITextView *)feedbackTextViewWithBackgroundColor:(UIColor *)backgroundColor;
 

--- a/WootricSDK/WootricSDK/UIItems.m
+++ b/WootricSDK/WootricSDK/UIItems.m
@@ -46,7 +46,7 @@
   }
 }
 
-+ (UILabel *)likelyAnchorWithSettings:(WTRSettings *)settings andFont:(UIFont *)font {
++ (UILabel *)likelyAnchorWithSettings:(WTRSettings *)settings font:(UIFont *)font {
   UILabel *tempLabel = [[UILabel alloc] init];
   tempLabel.textColor = [WTRColor anchorAndScoreColor];
   tempLabel.text = [settings likelyAnchorText];
@@ -56,7 +56,7 @@
   return tempLabel;
 }
 
-+ (UILabel *)notLikelyAnchorWithSettings:(WTRSettings *)settings andFont:(UIFont *)font {
++ (UILabel *)notLikelyAnchorWithSettings:(WTRSettings *)settings font:(UIFont *)font {
   UILabel *tempLabel = [[UILabel alloc] init];
   tempLabel.textColor = [WTRColor anchorAndScoreColor];
   tempLabel.text = [settings notLikelyAnchorText];
@@ -104,7 +104,7 @@
   return tempTextView;
 }
 
-+ (UILabel *)questionLabelWithSettings:(WTRSettings *)settings andFont:(UIFont *)font {
++ (UILabel *)questionLabelWithSettings:(WTRSettings *)settings font:(UIFont *)font {
   UILabel *tempLabel = [[UILabel alloc] init];
   tempLabel.textAlignment = NSTextAlignmentCenter;
   tempLabel.textColor = [UIColor blackColor];
@@ -117,7 +117,7 @@
   return tempLabel;
 }
 
-+ (UILabel *)finalThankYouLabelWithSettings:(WTRSettings *)settings textColor:(UIColor *)textColor andFont:(UIFont *)font {
++ (UILabel *)thankYouMainLabelWithSettings:(WTRSettings *)settings textColor:(UIColor *)textColor font:(UIFont *)font {
   UILabel *tempLabel = [[UILabel alloc] init];
   tempLabel.textAlignment = NSTextAlignmentCenter;
   tempLabel.textColor = textColor;
@@ -130,7 +130,7 @@
   return tempLabel;
 }
 
-+ (UILabel *)customThankYouLabelWithFont:(UIFont *)font {
++ (UILabel *)thankYouSetupLabelWithFont:(UIFont *)font {
   UILabel *tempLabel = [[UILabel alloc] init];
   tempLabel.textAlignment = NSTextAlignmentCenter;
   tempLabel.textColor = [UIColor blackColor];

--- a/WootricSDK/WootricSDK/WTRCustomSocial.h
+++ b/WootricSDK/WootricSDK/WTRCustomSocial.h
@@ -1,8 +1,8 @@
 //
-//  WTRiPADSocialShareView.h
+//  WTRCustomSocial.h
 //  WootricSDK
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+// Copyright (c) 2019 Wootric (https://wootric.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <UIKit/UIKit.h>
-#import "WTRSettings.h"
+#import <Foundation/Foundation.h>
 
-@interface WTRiPADSocialShareView : UIView
+@interface WTRCustomSocial : NSObject
 
-- (instancetype)initWithSettings:(WTRSettings *)settings;
-- (void)setupSubviewsConstraints;
-- (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
-- (void)noThankYouButton;
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)text;
-- (void)setThankYouMainDependingOnScore:(int)score;
-- (void)setThankYouSetupDependingOnScore:(int)score;
-- (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;
+@property (nonatomic, strong) NSString *twitterHandler;
+@property (nonatomic, strong) NSURL *facebookPage;
+
+- (instancetype)initWithCustomSocial:(NSDictionary *)customSocial;
+- (BOOL)socialEnabled;
 
 @end

--- a/WootricSDK/WootricSDK/WTRCustomSocial.m
+++ b/WootricSDK/WootricSDK/WTRCustomSocial.m
@@ -1,8 +1,8 @@
 //
-//  WTRiPADSocialShareView.h
+//  WTRCustomSocial.m
 //  WootricSDK
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+// Copyright (c) 2019 Wootric (https://wootric.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <UIKit/UIKit.h>
-#import "WTRSettings.h"
+#import "WTRCustomSocial.h"
 
-@interface WTRiPADSocialShareView : UIView
+@implementation WTRCustomSocial {
+  BOOL isSocialEnabled;
+}
 
-- (instancetype)initWithSettings:(WTRSettings *)settings;
-- (void)setupSubviewsConstraints;
-- (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
-- (void)noThankYouButton;
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)text;
-- (void)setThankYouMainDependingOnScore:(int)score;
-- (void)setThankYouSetupDependingOnScore:(int)score;
-- (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;
+- (instancetype)initWithCustomSocial:(NSDictionary *)customSocial {
+  if (self = [super init]) {
+    isSocialEnabled = NO;
+    
+    if (customSocial[@"facebook_enabled"]) {
+      isSocialEnabled = YES;
+      _facebookPage = [NSURL URLWithString:customSocial[@"accounts"][@"facebook_page"]];
+    }
+    
+    if (customSocial[@"twitter_enabled"]) {
+      isSocialEnabled = YES;
+      _twitterHandler = customSocial[@"accounts"][@"twitter_account"];
+    }
+  }
+  return self;
+}
+
+- (BOOL)socialEnabled {
+  return isSocialEnabled;
+}
 
 @end

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.m
@@ -26,4 +26,44 @@
 
 @implementation WTRCustomThankYou
 
+- (instancetype)initWithCustomThankYou:(NSDictionary *)customThankYou {
+  if (self = [super init]) {
+    NSDictionary *thankYouMessages = customThankYou[@"thank_you_messages"];
+    NSDictionary *thankYouLinks = customThankYou[@"thank_you_links"];
+
+    if (thankYouMessages) {
+      _thankYouSetup = thankYouMessages[@"thank_you_setup"] ? thankYouMessages[@"thank_you_setup"] : nil;
+      if (thankYouMessages[@"thank_you_main"]) {
+        _thankYouMain = thankYouMessages[@"thank_you_main"];
+      } else {
+        _detractorThankYouMain = thankYouMessages[@"thank_you_main_list"][@"detractor_thank_you_main"];
+        _detractorThankYouSetup = thankYouMessages[@"thank_you_setup_list"][@"detractor_thank_you_setup"];
+        _passiveThankYouMain = thankYouMessages[@"thank_you_main_list"][@"passive_thank_you_main"];
+        _passiveThankYouSetup = thankYouMessages[@"thank_you_setup_list"][@"passive_thank_you_setup"];
+        _promoterThankYouMain = thankYouMessages[@"thank_you_main_list"][@"promoter_thank_you_main"];
+        _promoterThankYouSetup = thankYouMessages[@"thank_you_setup_list"][@"promoter_thank_you_setup"];
+      }
+    }
+
+    if (thankYouLinks) {
+      if (thankYouLinks[@"thank_you_link_text"] && thankYouLinks[@"thank_you_link_url"]) {
+        _thankYouLinkText = thankYouLinks[@"thank_you_link_text"];
+        _thankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url"]];
+      } else {
+        _detractorThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"detractor_thank_you_link_text"];
+        _detractorThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"detractor_thank_you_link_url"]];
+        _passiveThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"passive_thank_you_link_text"];
+        _passiveThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"passive_thank_you_link_url"]];
+        _promoterThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"promoter_thank_you_link_text"];
+        _promoterThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"promoter_thank_you_link_url"]];
+      }
+    }
+  }
+  return self;
+}
+
+- (BOOL)hasShareConfiguration {
+  return (_promoterThankYouLinkText && _promoterThankYouLinkURL);
+}
+
 @end

--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -119,22 +119,18 @@
 
 - (void)setupQuestionLabel {
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    _questionLabel = [UIItems questionLabelWithSettings:_settings
-                                                      andFont:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
+    _questionLabel = [UIItems questionLabelWithSettings:_settings font:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
   } else {
-    _questionLabel = [UIItems questionLabelWithSettings:_settings
-                                                      andFont:[UIFont systemFontOfSize:18]];
+    _questionLabel = [UIItems questionLabelWithSettings:_settings font:[UIFont systemFontOfSize:18]];
   }
 }
 
 - (void)setupLikelyAnchor {
-  _likelyAnchor = [UIItems likelyAnchorWithSettings:_settings
-                                            andFont:[UIFont systemFontOfSize:14]];
+  _likelyAnchor = [UIItems likelyAnchorWithSettings:_settings font:[UIFont systemFontOfSize:14]];
 }
 
 - (void)setupNotLikelyAnchor {
-  _notLikelyAnchor = [UIItems notLikelyAnchorWithSettings:_settings
-                                                  andFont:[UIFont systemFontOfSize:14]];
+  _notLikelyAnchor = [UIItems notLikelyAnchorWithSettings:_settings font:[UIFont systemFontOfSize:14]];
 }
 
 - (void)setupSliderWithSuperview:(UIView *)superview andViewController:(UIViewController *)viewController {

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -30,7 +30,6 @@
 @property (nonatomic, strong) NSString *endUserEmail;
 @property (nonatomic, strong) NSString *originURL;
 @property (nonatomic, strong) NSString *productName;
-@property (nonatomic, strong) NSString *twitterHandler;
 @property (nonatomic, strong) NSString *customProductName;
 @property (nonatomic, strong) NSString *languageCode;
 @property (nonatomic, strong) NSString *surveyType;
@@ -48,7 +47,6 @@
 @property (nonatomic, strong) NSNumber *dailyResponseCap;
 @property (nonatomic, strong) NSNumber *externalCreatedAt;
 @property (nonatomic, strong) NSNumber *firstSurveyAfter;
-@property (nonatomic, strong) NSURL *facebookPage;
 @property (nonatomic, strong) NSMutableDictionary *customProperties;
 @property (nonatomic, assign) NSInteger surveyedDefaultDuration;
 @property (nonatomic, assign) NSInteger surveyedDefaultDurationDecline;
@@ -82,7 +80,6 @@
 - (NSString *)sendButtonText;
 - (NSString *)dismissButtonText;
 - (NSString *)editScoreButtonText;
-- (NSString *)socialShareQuestionText;
 - (NSString *)socialShareDeclineText;
 
 
@@ -92,20 +89,29 @@
 - (void)setCustomFollowupPlaceholderForPromoter:(NSString *)promoterPlaceholder passive:(NSString *)passivePlaceholder detractor:(NSString *)detractorPlaceholder;
 - (void)setCustomFollowupQuestionForPromoter:(NSString *)promoterQuestion passive:(NSString *)passiveQuestion detractor:(NSString *)detractorQuestion;
 
-- (void)setThankYouMessage:(NSString *)thankYouMessage;
-- (void)setDetractorThankYouMessage:(NSString *)detractorThankYouMessage;
-- (void)setPassiveThankYouMessage:(NSString *)passiveThankYouMessage;
-- (void)setPromoterThankYouMessage:(NSString *)promoterThankYouMessage;
+- (void)setThankYouMain:(NSString *)thankYouMain;
+- (void)setDetractorThankYouMain:(NSString *)detractorThankYouMain;
+- (void)setPassiveThankYouMain:(NSString *)passiveThankYouMain;
+- (void)setPromoterThankYouMain:(NSString *)promoterThankYouMain;
+- (void)setThankYouSetup:(NSString *)thankYouSetup;
+- (void)setDetractorThankYouSetup:(NSString *)detractorThankYouSetup;
+- (void)setPassiveThankYouSetup:(NSString *)passiveThankYouSetup;
+- (void)setPromoterThankYouSetup:(NSString *)promoterThankYouSetup;
 - (void)setThankYouLinkWithText:(NSString *)thankYouLinkText URL:(NSURL *)thankYouLinkURL;
 - (void)setDetractorThankYouLinkWithText:(NSString *)detractorThankYouLinkText URL:(NSURL *)detractorThankYouLinkURL;
 - (void)setPassiveThankYouLinkWithText:(NSString *)passiveThankYouLinkText URL:(NSURL *)passiveThankYouLinkURL;
 - (void)setPromoterThankYouLinkWithText:(NSString *)promoterThankYouLinkText URL:(NSURL *)promoterThankYouLinkURL;
 
-- (NSString *)thankYouMessageDependingOnScore:(int)score;
+- (NSString *)thankYouMainDependingOnScore:(int)score;
+- (NSString *)thankYouSetupDependingOnScore:(int)score;
 - (NSString *)thankYouLinkTextDependingOnScore:(int)score;
 - (NSURL *)thankYouLinkURLDependingOnScore:(int)score andText:(NSString *)text;
 - (BOOL)thankYouLinkConfiguredForScore:(int)score;
 
+- (void)setTwitterHandler:(NSString *)twitterHandler;
+- (void)setFacebookPage:(NSURL *)facebookPage;
+- (NSString *)twitterHandler;
+- (NSURL *)facebookPage;
 - (BOOL)twitterHandlerSet;
 - (BOOL)facebookPageSet;
 

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -26,7 +26,9 @@
 #import "WTRLocalizedTexts.h"
 #import "WTRCustomMessages.h"
 #import "WTRCustomThankYou.h"
+#import "WTRCustomSocial.h"
 #import "WTRUserCustomMessages.h"
+#import "WTRUserCustomThankYou.h"
 #import "WTRColor.h"
 
 @interface WTRSettings ()
@@ -34,7 +36,10 @@
 @property (nonatomic, strong) WTRLocalizedTexts *localizedTexts;
 @property (nonatomic, strong) WTRCustomMessages *customMessages;
 @property (nonatomic, strong) WTRCustomThankYou *customThankYou;
+@property (nonatomic, strong) WTRCustomSocial *customSocial;
 @property (nonatomic, strong) WTRUserCustomMessages *userCustomMessages;
+@property (nonatomic, strong) WTRUserCustomThankYou *userCustomThankYou;
+@property (nonatomic, strong) WTRCustomSocial *userCustomSocial;
 
 @end
 
@@ -48,8 +53,9 @@
     _surveyedDefaultDurationDecline = 30;
     _firstSurveyAfter = @0;
     _originURL = [[NSBundle mainBundle] bundleIdentifier];
-    _customThankYou = [[WTRCustomThankYou alloc] init];
+    _userCustomThankYou = [[WTRUserCustomThankYou alloc] init];
     _userCustomMessages = [[WTRUserCustomMessages alloc] init];
+    _userCustomSocial = [[WTRCustomSocial alloc] init];
     _timeDelay = -1;
     _surveyType = @"NPS";
     _scale = [self scoreRules][_surveyType][0];
@@ -62,10 +68,14 @@
 - (void)parseDataFromSurveyServer:(NSDictionary *)surveyServerSettings {
   NSDictionary *localizedTextsFromSurvey;
   NSDictionary *customMessagesFromSurvey;
+  NSDictionary *customThankYouFromSurvey;
+  NSDictionary *socialFromSurvey;
     
   if (surveyServerSettings[@"settings"]) {
     localizedTextsFromSurvey = surveyServerSettings[@"settings"][@"localized_texts"];
     customMessagesFromSurvey = surveyServerSettings[@"settings"][@"messages"];
+    customThankYouFromSurvey = surveyServerSettings[@"settings"][@"custom_thank_you"];
+    socialFromSurvey = surveyServerSettings[@"settings"][@"social"];
     NSString *surveyTypeFromSurvey = surveyServerSettings[@"settings"][@"survey_type"];
     NSInteger surveyTypeScaleFromSurvey = [surveyServerSettings[@"settings"][@"survey_type_scale"] integerValue];
     NSNumber *firstSurvey = surveyServerSettings[@"settings"][@"first_survey"];
@@ -90,6 +100,14 @@
 
     if (customMessagesFromSurvey) {
       _customMessages = [[WTRCustomMessages alloc] initWithCustomMessages:customMessagesFromSurvey];
+    }
+    
+    if (customThankYouFromSurvey) {
+      _customThankYou = [[WTRCustomThankYou alloc] initWithCustomThankYou:customThankYouFromSurvey];
+    }
+    
+    if (socialFromSurvey) {
+      _customSocial = [[WTRCustomSocial alloc] initWithCustomSocial:socialFromSurvey];
     }
 
     if (firstSurvey) {
@@ -256,6 +274,7 @@
   if (_customFinalThankYou) {
     return _customFinalThankYou;
   }
+
   return _localizedTexts.finalThankYou;
 }
 
@@ -278,8 +297,8 @@
 }
 
 - (UIColor *)thankYouButtonBackgroundColor {
-  if (_customThankYou.backgroundColor) {
-    return _customThankYou.backgroundColor;
+  if (_userCustomThankYou.backgroundColor) {
+    return _userCustomThankYou.backgroundColor;
   }
   return [WTRColor callToActionButtonBackgroundColor];
 }
@@ -299,52 +318,64 @@
   return _localizedTexts.editScore;
 }
 
-- (NSString *)socialShareQuestionText {
-  return _localizedTexts.socialShareQuestion;
-}
-
 - (NSString *)socialShareDeclineText {
   return _localizedTexts.socialShareDecline;
 }
 
 - (void)setThankYouButtonBackgroundColor:(UIColor *)thankYouButtonBackgroundColor {
-  _customThankYou.backgroundColor = thankYouButtonBackgroundColor;
+  _userCustomThankYou.backgroundColor = thankYouButtonBackgroundColor;
 }
 
-- (void)setThankYouMessage:(NSString *)thankYouMessage {
-  _customThankYou.thankYouMessage = thankYouMessage;
+- (void)setThankYouMain:(NSString *)thankYouMain {
+  _userCustomThankYou.thankYouMain = thankYouMain;
 }
 
-- (void)setDetractorThankYouMessage:(NSString *)detractorThankYouMessage {
-  _customThankYou.detractorThankYouMessage = detractorThankYouMessage;
+- (void)setDetractorThankYouMain:(NSString *)detractorThankYouMain {
+  _userCustomThankYou.detractorThankYouMain = detractorThankYouMain;
 }
 
-- (void)setPassiveThankYouMessage:(NSString *)passiveThankYouMessage {
-  _customThankYou.passiveThankYouMessage = passiveThankYouMessage;
+- (void)setPassiveThankYouMain:(NSString *)passiveThankYouMain {
+  _userCustomThankYou.passiveThankYouMain = passiveThankYouMain;
 }
 
-- (void)setPromoterThankYouMessage:(NSString *)promoterThankYouMessage {
-  _customThankYou.promoterThankYouMessage = promoterThankYouMessage;
+- (void)setPromoterThankYouMain:(NSString *)promoterThankYouMain {
+  _userCustomThankYou.promoterThankYouMain = promoterThankYouMain;
+}
+
+- (void)setThankYouSetup:(NSString *)thankYouMain {
+  _userCustomThankYou.thankYouMain = thankYouMain;
+}
+
+- (void)setDetractorThankYouSetup:(NSString *)detractorThankYouSetup {
+  _userCustomThankYou.detractorThankYouSetup = detractorThankYouSetup;
+}
+
+- (void)setPassiveThankYouSetup:(NSString *)passiveThankYouSetup {
+  _userCustomThankYou.passiveThankYouSetup = passiveThankYouSetup;
+}
+
+- (void)setPromoterThankYouSetup:(NSString *)promoterThankYouSetup {
+  _userCustomThankYou.promoterThankYouSetup = promoterThankYouSetup;
 }
 
 - (void)setThankYouLinkWithText:(NSString *)thankYouLinkText URL:(NSURL *)thankYouLinkURL {
-  _customThankYou.thankYouLinkText = thankYouLinkText;
-  _customThankYou.thankYouLinkURL = thankYouLinkURL;
+  _userCustomThankYou.thankYouLinkText = thankYouLinkText;
+  _userCustomThankYou.thankYouLinkURL = thankYouLinkURL;
 }
 
 - (void)setDetractorThankYouLinkWithText:(NSString *)detractorThankYouLinkText URL:(NSURL *)detractorThankYouLinkURL {
-  _customThankYou.detractorThankYouLinkText = detractorThankYouLinkText;
-  _customThankYou.detractorThankYouLinkURL = detractorThankYouLinkURL;
+  _userCustomThankYou.detractorThankYouLinkText = detractorThankYouLinkText;
+  _userCustomThankYou.detractorThankYouLinkURL = detractorThankYouLinkURL;
 }
 
 - (void)setPassiveThankYouLinkWithText:(NSString *)passiveThankYouLinkText URL:(NSURL *)passiveThankYouLinkURL {
-  _customThankYou.passiveThankYouLinkText = passiveThankYouLinkText;
-  _customThankYou.passiveThankYouLinkURL = passiveThankYouLinkURL;
+  _userCustomThankYou.passiveThankYouLinkText = passiveThankYouLinkText;
+  _userCustomThankYou.passiveThankYouLinkURL = passiveThankYouLinkURL;
 }
 
 - (void)setPromoterThankYouLinkWithText:(NSString *)promoterThankYouLinkText URL:(NSURL *)promoterThankYouLinkURL {
-  _customThankYou.promoterThankYouLinkText = promoterThankYouLinkText;
-  _customThankYou.promoterThankYouLinkURL = promoterThankYouLinkURL;
+  _userCustomThankYou.promoterThankYouLinkText = promoterThankYouLinkText;
+  _userCustomThankYou.promoterThankYouLinkURL = promoterThankYouLinkURL;
 }
 
 - (void)setCustomFollowupQuestionForPromoter:(NSString *)promoterQuestion passive:(NSString *)passiveQuestion detractor:(NSString *)detractorQuestion {
@@ -359,65 +390,81 @@
   _userCustomMessages.detractorPlaceholderText = detractorPlaceholder;
 }
 
-- (NSString *)thankYouMessageDependingOnScore:(int)score {
-    
-  if ([self negativeTypeScore:score] && _customThankYou.detractorThankYouMessage) {
-    return _customThankYou.detractorThankYouMessage;
-  } else if ([self neutralTypeScore:score] && _customThankYou.passiveThankYouMessage) {
-    return _customThankYou.passiveThankYouMessage;
-  } else if ([self positiveTypeScore:score] && _customThankYou.promoterThankYouMessage) {
-    return _customThankYou.promoterThankYouMessage;
-  } else if (_customThankYou.thankYouMessage) {
-    return _customThankYou.thankYouMessage;
+- (NSString *)thankYouMainDependingOnScore:(int)score {
+  if ([self negativeTypeScore:score] && (_customThankYou.detractorThankYouMain || _userCustomThankYou.detractorThankYouMain)) {
+    return [self detractorThankYouMain];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.passiveThankYouMain || _userCustomThankYou.passiveThankYouMain)) {
+    return [self passiveThankYouMain];
+  } else if ([self positiveTypeScore:score] && (_customThankYou.promoterThankYouMain || _userCustomThankYou.promoterThankYouMain)) {
+    return [self promoterThankYouMain];
+  } else if (_customThankYou.thankYouMain || _userCustomThankYou.thankYouMain) {
+    return [self thankYouMain];
   }
     
+  return _localizedTexts.finalThankYou;
+}
+
+- (NSString *)thankYouSetupDependingOnScore:(int)score {
+  if ([self positiveTypeScore:score]) {
+    if (_customThankYou.promoterThankYouSetup || _userCustomThankYou.promoterThankYouSetup) {
+      return [self promoterThankYouSetup];
+    } else if ([_customThankYou hasShareConfiguration] || [_userCustomThankYou hasShareConfiguration] || _customSocial.twitterHandler || _customSocial.facebookPage) {
+      return _localizedTexts.socialShareQuestion;
+    }
+  } else if ([self negativeTypeScore:score] && (_customThankYou.detractorThankYouSetup || _userCustomThankYou.detractorThankYouSetup)) {
+    return [self detractorThankYouSetup];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.passiveThankYouSetup || _userCustomThankYou.passiveThankYouSetup)) {
+    return [self passiveThankYouSetup];
+  }
+  
+  if (_customThankYou.thankYouSetup || _userCustomThankYou.thankYouSetup) {
+    return [self thankYouSetup];
+  }
+  
   return nil;
 }
 
 - (NSString *)thankYouLinkTextDependingOnScore:(int)score {
-    
-  if ([self negativeTypeScore:score] && _customThankYou.detractorThankYouLinkText) {
-    return _customThankYou.detractorThankYouLinkText;
-  } else if ([self neutralTypeScore:score] && _customThankYou.passiveThankYouLinkText) {
-    return _customThankYou.passiveThankYouLinkText;
-  } else if ([self positiveTypeScore:score] && _customThankYou.promoterThankYouLinkText) {
-    return _customThankYou.promoterThankYouLinkText;
-  } else if (_customThankYou.thankYouLinkText) {
-    return _customThankYou.thankYouLinkText;
+  if ([self negativeTypeScore:score] && (_customThankYou.detractorThankYouLinkText || _userCustomThankYou.detractorThankYouLinkText)) {
+    return [self detractorThankYouLinkText];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.passiveThankYouLinkText || _userCustomThankYou.passiveThankYouLinkText)) {
+    return [self passiveThankYouLinkText];
+  } else if ([self positiveTypeScore:score] && (_customThankYou.promoterThankYouLinkText || _userCustomThankYou.promoterThankYouLinkText)) {
+    return [self promoterThankYouLinkText];
+  } else if (_customThankYou.thankYouLinkText || _userCustomThankYou.thankYouLinkText) {
+    return [self thankYouLinkText];
   }
     
   return nil;
 }
 
 - (NSURL *)thankYouLinkURLDependingOnScore:(int)score andText:(NSString *)text {
-    
-  if ([self negativeTypeScore:score] && _customThankYou.detractorThankYouLinkURL) {
+  if ([self negativeTypeScore:score] && (_customThankYou.detractorThankYouLinkURL || _userCustomThankYou.detractorThankYouLinkURL)) {
     if (_passScoreAndTextToURL) {
-      return [self url:_customThankYou.detractorThankYouLinkURL withScore:score andText:text];
+      return [self detractorThankYouLinkURLWithScore:score text:text];
     }
-    return _customThankYou.detractorThankYouLinkURL;
-  } else if ([self neutralTypeScore:score] && _customThankYou.passiveThankYouLinkURL) {
+    return [self detractorThankYouLinkURL];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.passiveThankYouLinkURL || _userCustomThankYou.passiveThankYouLinkURL)) {
     if (_passScoreAndTextToURL) {
-      return [self url:_customThankYou.passiveThankYouLinkURL withScore:score andText:text];
+      return [self passiveThankYouLinkURLWithScore:score text:text];
     }
-    return _customThankYou.passiveThankYouLinkURL;
-  } else if ([self positiveTypeScore:score] && _customThankYou.promoterThankYouLinkURL) {
+    return [self passiveThankYouLinkURL];;
+  } else if ([self positiveTypeScore:score] && (_customThankYou.promoterThankYouLinkURL || _userCustomThankYou.promoterThankYouLinkURL)) {
     if (_passScoreAndTextToURL) {
-      return [self url:_customThankYou.promoterThankYouLinkURL withScore:score andText:text];
+      return [self promoterThankYouLinkURLWithScore:score text:text];
     }
-    return _customThankYou.promoterThankYouLinkURL;
-  } else if (_customThankYou.thankYouLinkURL) {
+    return [self promoterThankYouLinkURL];
+  } else if (_customThankYou.thankYouLinkURL || _userCustomThankYou.thankYouLinkURL) {
     if (_passScoreAndTextToURL) {
-      return [self url:_customThankYou.thankYouLinkURL withScore:score andText:text];
+      return [self thankYouLinkURLWithScore:score text:text];
     }
-    return _customThankYou.thankYouLinkURL;
+    return [self thankYouLinkURL];
   }
   
   return nil;
 }
 
 - (BOOL)thankYouLinkConfiguredForScore:(int)score {
-    
   if ([self negativeTypeScore:score] && [self detractorOrDefaultURL] && [self detractorOrDefaultText]) {
     return YES;
   }
@@ -434,36 +481,248 @@
   return NO;
 }
 
+- (NSString *)detractorThankYouMain {
+  if (_userCustomThankYou.detractorThankYouMain) {
+    return _userCustomThankYou.detractorThankYouMain;
+  }
+  
+  return _customThankYou.detractorThankYouMain;
+}
+
+- (NSString *)passiveThankYouMain {
+  if (_userCustomThankYou.passiveThankYouMain) {
+    return _userCustomThankYou.passiveThankYouMain;
+  }
+  
+  return _customThankYou.passiveThankYouMain;
+}
+
+- (NSString *)promoterThankYouMain {
+  if (_userCustomThankYou.promoterThankYouMain) {
+    return _userCustomThankYou.promoterThankYouMain;
+  }
+  
+  return _customThankYou.promoterThankYouMain;
+}
+
+- (NSString *)thankYouMain {
+  if (_userCustomThankYou.thankYouMain) {
+    return _userCustomThankYou.thankYouMain;
+  }
+  
+  return _customThankYou.thankYouMain;
+}
+
+- (NSString *)detractorThankYouSetup {
+  if (_userCustomThankYou.detractorThankYouSetup) {
+    return _userCustomThankYou.detractorThankYouSetup;
+  }
+  
+  return _customThankYou.detractorThankYouSetup;
+}
+
+- (NSString *)passiveThankYouSetup {
+  if (_userCustomThankYou.passiveThankYouSetup) {
+    return _userCustomThankYou.passiveThankYouSetup;
+  }
+  
+  return _customThankYou.passiveThankYouSetup;
+}
+
+- (NSString *)promoterThankYouSetup {
+  if (_userCustomThankYou.promoterThankYouSetup) {
+    return _userCustomThankYou.promoterThankYouSetup;
+  }
+  
+  return _customThankYou.promoterThankYouSetup;
+}
+
+- (NSString *)thankYouSetup {
+  if (_userCustomThankYou.thankYouSetup) {
+    return _userCustomThankYou.thankYouSetup;
+  }
+  
+  return _customThankYou.thankYouSetup;
+}
+
+- (NSString *)detractorThankYouLinkText {
+  if (_userCustomThankYou.detractorThankYouLinkText) {
+    return _userCustomThankYou.detractorThankYouLinkText;
+  }
+  
+  return _customThankYou.detractorThankYouLinkText;
+}
+
+- (NSString *)passiveThankYouLinkText {
+  if (_userCustomThankYou.passiveThankYouLinkText) {
+    return _userCustomThankYou.passiveThankYouLinkText;
+  }
+  
+  return _customThankYou.passiveThankYouLinkText;
+}
+
+- (NSString *)promoterThankYouLinkText {
+  if (_userCustomThankYou.promoterThankYouLinkText) {
+    return _userCustomThankYou.promoterThankYouLinkText;
+  }
+  
+  return _customThankYou.promoterThankYouLinkText;
+}
+
+- (NSString *)thankYouLinkText {
+  if (_userCustomThankYou.thankYouLinkText) {
+    return _userCustomThankYou.thankYouLinkText;
+  }
+  
+  return _customThankYou.thankYouLinkText;
+}
+
+- (NSURL *)detractorThankYouLinkURL {
+  if (_userCustomThankYou.detractorThankYouLinkURL) {
+    return _userCustomThankYou.detractorThankYouLinkURL;
+  }
+  
+  return _customThankYou.detractorThankYouLinkURL;
+}
+
+- (NSURL *)passiveThankYouLinkURL {
+  if (_userCustomThankYou.passiveThankYouLinkURL) {
+    return _userCustomThankYou.passiveThankYouLinkURL;
+  }
+  
+  return _customThankYou.passiveThankYouLinkURL;
+}
+
+- (NSURL *)promoterThankYouLinkURL {
+  if (_userCustomThankYou.promoterThankYouLinkURL) {
+    return _userCustomThankYou.promoterThankYouLinkURL;
+  }
+  
+  return _customThankYou.promoterThankYouLinkURL;
+}
+
+- (NSURL *)thankYouLinkURL {
+  if (_userCustomThankYou.thankYouLinkURL) {
+    return _userCustomThankYou.thankYouLinkURL;
+  }
+  
+  return _customThankYou.thankYouLinkURL;
+}
+
+- (NSURL *)detractorThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+  if (_userCustomThankYou.detractorThankYouLinkURL) {
+    return [self url:_userCustomThankYou.detractorThankYouLinkURL withScore:score andText:text];
+  }
+  
+  return [self url:_customThankYou.detractorThankYouLinkURL withScore:score andText:text];
+}
+
+- (NSURL *)passiveThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+  if (_userCustomThankYou.passiveThankYouLinkURL) {
+    return [self url:_userCustomThankYou.passiveThankYouLinkURL withScore:score andText:text];
+  }
+  
+  return [self url:_customThankYou.passiveThankYouLinkURL withScore:score andText:text];
+}
+- (NSURL *)promoterThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+  if (_userCustomThankYou.promoterThankYouLinkURL) {
+    return [self url:_userCustomThankYou.promoterThankYouLinkURL withScore:score andText:text];
+  }
+  
+  return [self url:_customThankYou.promoterThankYouLinkURL withScore:score andText:text];
+}
+- (NSURL *)thankYouLinkURLWithScore:(int)score text:(NSString *)text {
+  if (_userCustomThankYou.thankYouLinkURL) {
+    return [self url:_userCustomThankYou.thankYouLinkURL withScore:score andText:text];
+  }
+  
+  return [self url:_customThankYou.thankYouLinkURL withScore:score andText:text];
+}
+
 - (BOOL)detractorOrDefaultURL {
-  return (_customThankYou.detractorThankYouLinkURL || _customThankYou.thankYouLinkURL);
+  return ([self detractorURL] || [self defaultURL]);
 }
 
 - (BOOL)detractorOrDefaultText {
-  return (_customThankYou.detractorThankYouLinkText || _customThankYou.thankYouLinkText);
+  return ([self detractorText] || [self defaultText]);
 }
 
 - (BOOL)passiveOrDefaultURL {
-  return (_customThankYou.passiveThankYouLinkURL || _customThankYou.thankYouLinkURL);
+  return ([self passiveURL] || [self defaultURL]);
 }
 
 - (BOOL)passiveOrDefaultText {
-  return (_customThankYou.passiveThankYouLinkText || _customThankYou.thankYouLinkText);
+  return ([self passiveText] || [self defaultText]);
 }
 
 - (BOOL)promoterOrDefaultURL {
-  return (_customThankYou.promoterThankYouLinkURL || _customThankYou.thankYouLinkURL);
+  return ([self promoterURL] || [self defaultURL]);
 }
 
 - (BOOL)promoterOrDefaultText {
-  return (_customThankYou.promoterThankYouLinkText || _customThankYou.thankYouLinkText);
+  return ([self promoterText] || [self defaultText]);
+}
+
+- (BOOL)detractorURL {
+  return (_customThankYou.detractorThankYouLinkURL || _userCustomThankYou.detractorThankYouLinkURL);
+}
+
+- (BOOL)passiveURL {
+  return (_customThankYou.passiveThankYouLinkURL || _userCustomThankYou.passiveThankYouLinkURL);
+}
+
+- (BOOL)promoterURL {
+  return (_customThankYou.promoterThankYouLinkURL || _userCustomThankYou.promoterThankYouLinkURL);
+}
+
+- (BOOL)defaultURL {
+  return (_customThankYou.thankYouLinkURL || _userCustomThankYou.thankYouLinkURL);
+}
+
+- (BOOL)detractorText {
+  return (_customThankYou.detractorThankYouLinkText || _userCustomThankYou.detractorThankYouLinkText);
+}
+
+- (BOOL)passiveText {
+  return (_customThankYou.passiveThankYouLinkText || _userCustomThankYou.passiveThankYouLinkText);
+}
+
+- (BOOL)promoterText {
+  return (_customThankYou.promoterThankYouLinkText || _userCustomThankYou.promoterThankYouLinkText);
+}
+
+- (BOOL)defaultText {
+  return (_customThankYou.thankYouLinkText || _userCustomThankYou.thankYouLinkText);
+}
+
+- (void)setTwitterHandler:(NSString *)twitterHandler {
+  [_userCustomSocial setTwitterHandler:twitterHandler];
+}
+
+- (void)setFacebookPage:(NSURL *)facebookPage {
+  [_userCustomSocial setFacebookPage:facebookPage];
+}
+
+- (NSString *)twitterHandler {
+  if (_userCustomSocial.twitterHandler) {
+    return _userCustomSocial.twitterHandler;
+  }
+  return _customSocial.twitterHandler;
+}
+
+- (NSURL *)facebookPage {
+  if (_userCustomSocial.facebookPage) {
+    return _userCustomSocial.facebookPage;
+  }
+  return _customSocial.facebookPage;
 }
 
 - (BOOL)twitterHandlerSet {
-  return !!_twitterHandler;
+  return !!(_customSocial.twitterHandler || _userCustomSocial.twitterHandler);
 }
 
 - (BOOL)facebookPageSet {
-  return !!_facebookPage;
+  return !!(_customSocial.facebookPage || _userCustomSocial.facebookPage);
 }
 
 - (void)setCustomResurveyThrottle:(NSNumber *)customResurveyThrottle {

--- a/WootricSDK/WootricSDK/WTRSlider.m
+++ b/WootricSDK/WootricSDK/WTRSlider.m
@@ -48,7 +48,10 @@
     _sliderColor = color;
     _currentValue = -1;
 
-    [self setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+    if ([self respondsToSelector:NSSelectorFromString(@"setSemanticContentAttribute:")]) {
+      [self setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+    }
+    
 
     self.minimumValue = [_settings minimumScore];
     self.maximumValue = [_settings maximumScore];

--- a/WootricSDK/WootricSDK/WTRSocialShareView.h
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.h
@@ -31,7 +31,8 @@
 - (void)setupSubviewsConstraints;
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
 - (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)feedbackText;
-- (void)setThankYouMessageDependingOnScore:(int)score;
+- (void)setThankYouMainDependingOnScore:(int)score;
+- (void)setThankYouSetupDependingOnScore:(int)score;
 - (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;
 
 @end

--- a/WootricSDK/WootricSDK/WTRSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.m
@@ -37,12 +37,15 @@
 @property (nonatomic, strong) UIButton *facebookButton;
 @property (nonatomic, strong) UIButton *twitterButton;
 @property (nonatomic, strong) UIButton *facebookLikeButton;
-@property (nonatomic, strong) UILabel *finalThankYouLabel;
-@property (nonatomic, strong) UILabel *socialShareQuestionLabel;
-@property (nonatomic, strong) UILabel *customThankYouLabel;
+@property (nonatomic, strong) UILabel *thankYouMainLabel;
+@property (nonatomic, strong) UILabel *thankYouSetupLabel;
 @property (nonatomic, strong) NSLayoutConstraint *facebookXConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *twitterXConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *facebookLikeXConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *facebookTopConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *twitterTopConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *facebookLikeTopConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *thankYouButtonTopConstraint;
 
 @end
 
@@ -65,6 +68,14 @@
   NSString *text = [_settings thankYouLinkTextDependingOnScore:score];
   NSURL *url = [_settings thankYouLinkURLDependingOnScore:score andText:feedbackText];
 
+  if (!text || !url) {
+    _thankYouButton.hidden = YES;
+    [self setupFacebookButtonTopConstraints:_thankYouSetupLabel];
+    [self setupTwitterButtonTopConstraints:_thankYouSetupLabel];
+    [self setupFacebookLikeButtonTopConstraints:_thankYouSetupLabel];
+    return;
+  }
+
   [_thankYouButton setText:text andURL:url];
 }
 
@@ -85,21 +96,28 @@
   } else if (!twitterAvailable && facebookAvailable) {
     _facebookLikeXConstraint.constant = 32;
     _facebookXConstraint.constant = -32;
-  } else if (!twitterAvailable && !facebookAvailable) {
-    _socialShareQuestionLabel.hidden = YES;
   }
 }
 
-- (void)setThankYouMessageDependingOnScore:(int)score {
-  _customThankYouLabel.text = [_settings thankYouMessageDependingOnScore:score];
+- (void)setThankYouMainDependingOnScore:(int)score {
+  _thankYouMainLabel.text = [_settings thankYouMainDependingOnScore:score];
+}
+
+- (void)setThankYouSetupDependingOnScore:(int)score {
+  _thankYouSetupLabel.text = [_settings thankYouSetupDependingOnScore:score];
+  
+  if (!_thankYouSetupLabel.text) {
+    _thankYouSetupLabel.hidden = YES;
+    [self setupThankYouButtonTopConstraints:_thankYouMainLabel];
+    return;
+  }
 }
 
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController {
   [self setupThankYouButtonWithTargetViewController:viewController];
   [self setupNoThanksButtonWithTargetViewController:viewController];
-  [self setupSocialShareQuestionLabel];
-  [self setupFinalThankYouLabel];
-  [self setupCustomThankYouLabel];
+  [self setupThankYouMainLabel];
+  [self setupThankYouSetupLabel];
   [self setupFacebookButtonWithTargetViewController:viewController];
   [self setupTwitterButtonWithTargetViewController:viewController];
   [self setupFacebookLikeButtonWithTargetViewController:viewController];
@@ -107,11 +125,10 @@
 }
 
 - (void)setupSubviewsConstraints {
-  [self setupFinalThankYouLabelConstraints];
-  [self setupCustomThankYouLabelConstraints];
+  [self setupThankYouMainLabelConstraints];
+  [self setupThankYouSetupLabelConstraints];
   [self setupThankYouButtonConstraints];
   [self setupNoThanksButtonConstraints];
-  [self setupSocialShareQuestionLabelConstraints];
   [self setupFacebookButtonConstraints];
   [self setupTwitterButtonConstraints];
   [self setupFacebookLikeButtonConstraints];
@@ -120,16 +137,11 @@
 - (void)addSubviews {
   [self addSubview:_thankYouButton];
   [self addSubview:_noThanksButton];
-  [self addSubview:_socialShareQuestionLabel];
-  [self addSubview:_finalThankYouLabel];
-  [self addSubview:_customThankYouLabel];
+  [self addSubview:_thankYouMainLabel];
+  [self addSubview:_thankYouSetupLabel];
   [self addSubview:_facebookButton];
   [self addSubview:_twitterButton];
   [self addSubview:_facebookLikeButton];
-}
-
-- (void)setupCustomThankYouLabel {
-  _customThankYouLabel = [UIItems customThankYouLabelWithFont:[UIFont boldSystemFontOfSize:12]];
 }
 
 - (void)setupThankYouButtonWithTargetViewController:(UIViewController *)viewController {
@@ -159,39 +171,29 @@
             forControlEvents:UIControlEventTouchUpInside];
 }
 
-- (void)setupFinalThankYouLabel {
+- (void)setupThankYouMainLabel {
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    _finalThankYouLabel = [UIItems finalThankYouLabelWithSettings:_settings
-                                                        textColor:[UIColor blackColor]
-                                                          andFont:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
+    _thankYouMainLabel = [UIItems thankYouMainLabelWithSettings:_settings textColor:[UIColor blackColor] font:[UIFont systemFontOfSize:18 weight:UIFontWeightMedium]];
   } else {
-    _finalThankYouLabel = [UIItems finalThankYouLabelWithSettings:_settings
-                                                        textColor:[UIColor blackColor]
-                                                          andFont:[UIFont systemFontOfSize:18]];
+    _thankYouMainLabel = [UIItems thankYouMainLabelWithSettings:_settings textColor:[UIColor blackColor] font:[UIFont systemFontOfSize:18]];
   }
 }
 
-- (void)setupSocialShareQuestionLabel {
-  _socialShareQuestionLabel = [[UILabel alloc] init];
-  _socialShareQuestionLabel.textAlignment = NSTextAlignmentCenter;
-  _socialShareQuestionLabel.textColor = [_settings socialSharingColor];
-  _socialShareQuestionLabel.numberOfLines = 0;
-  _socialShareQuestionLabel.lineBreakMode = NSLineBreakByWordWrapping;
-  _socialShareQuestionLabel.font = [UIFont boldSystemFontOfSize:12];
-  _socialShareQuestionLabel.text = [_settings socialShareQuestionText];
-  [_socialShareQuestionLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
-}
-
-- (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_customThankYouLabel wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:8] addToView:self];
+- (void)setupThankYouSetupLabel {
+  _thankYouSetupLabel = [[UILabel alloc] init];
+  _thankYouSetupLabel.textAlignment = NSTextAlignmentCenter;
+  _thankYouSetupLabel.textColor = [_settings socialSharingColor];
+  _thankYouSetupLabel.numberOfLines = 0;
+  _thankYouSetupLabel.lineBreakMode = NSLineBreakByWordWrapping;
+  _thankYouSetupLabel.font = [UIFont boldSystemFontOfSize:12];
+  [_thankYouSetupLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
 }
 
 - (void)setupFacebookButtonConstraints {
   [_facebookButton wtr_constraintWidth:32];
   [_facebookButton wtr_constraintHeight:32];
-  [[[[_facebookButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+  
+  [self setupFacebookButtonTopConstraints:_thankYouButton];
 
   _facebookXConstraint = [NSLayoutConstraint constraintWithItem:_facebookButton
                                                       attribute:NSLayoutAttributeCenterX
@@ -203,10 +205,20 @@
   [self addConstraint:_facebookXConstraint];
 }
 
+- (void)setupFacebookButtonTopConstraints:(UIView *)secondViewBottom {
+  if (_facebookTopConstraint) {
+    [_facebookTopConstraint removeFromView:self];
+  }
+  
+  _facebookTopConstraint = [[[_facebookButton wtr_topConstraint] toSecondViewBottom:secondViewBottom] withConstant:18];
+  [_facebookTopConstraint addToView:self];
+}
+
 - (void)setupTwitterButtonConstraints {
   [_twitterButton wtr_constraintWidth:32];
   [_twitterButton wtr_constraintHeight:32];
-  [[[[_twitterButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+
+  [self setupTwitterButtonTopConstraints:_thankYouButton];
 
   _twitterXConstraint = [NSLayoutConstraint constraintWithItem:_twitterButton
                                                      attribute:NSLayoutAttributeCenterX
@@ -218,31 +230,52 @@
   [self addConstraint:_twitterXConstraint];
 }
 
+- (void)setupTwitterButtonTopConstraints:(UIView *)secondViewBottom {
+  if (_twitterTopConstraint) {
+    [_twitterTopConstraint removeFromView:self];
+  }
+  
+  _twitterTopConstraint = [[[_twitterButton wtr_topConstraint] toSecondViewBottom:secondViewBottom] withConstant:18];
+  [_twitterTopConstraint addToView:self];
+}
+
 - (void)setupFacebookLikeButtonConstraints {
-    [_facebookLikeButton wtr_constraintWidth:32];
-    [_facebookLikeButton wtr_constraintHeight:32];
-    [[[[_facebookLikeButton wtr_topConstraint] toSecondViewBottom:_socialShareQuestionLabel] withConstant:18] addToView:self];
+  [_facebookLikeButton wtr_constraintWidth:32];
+  [_facebookLikeButton wtr_constraintHeight:32];
+  
+  [self setupFacebookLikeButtonTopConstraints:_thankYouButton];
     
-    _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
-                                                        attribute:NSLayoutAttributeCenterX
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self
-                                                        attribute:NSLayoutAttributeCenterX
-                                                       multiplier:1
-                                                         constant:0];
-    [self addConstraint:_facebookLikeXConstraint];
+  _facebookLikeXConstraint = [NSLayoutConstraint constraintWithItem:_facebookLikeButton
+                                                      attribute:NSLayoutAttributeCenterX
+                                                      relatedBy:NSLayoutRelationEqual
+                                                         toItem:self
+                                                      attribute:NSLayoutAttributeCenterX
+                                                     multiplier:1
+                                                       constant:0];
+  [self addConstraint:_facebookLikeXConstraint];
 }
 
-- (void)setupSocialShareQuestionLabelConstraints {
-  [[[[_socialShareQuestionLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_socialShareQuestionLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_socialShareQuestionLabel wtr_topConstraint] toSecondViewBottom:_thankYouButton] withConstant:16] addToView:self];
+- (void)setupFacebookLikeButtonTopConstraints:(UIView *)secondViewBottom {
+  if (_facebookLikeTopConstraint) {
+    [_facebookLikeTopConstraint removeFromView:self];
+  }
+  
+  _facebookLikeTopConstraint = [[[_facebookLikeButton wtr_topConstraint] toSecondViewBottom:secondViewBottom] withConstant:18];
+  [_facebookLikeTopConstraint addToView:self];
 }
 
-- (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[self wtr_rightConstraint] toSecondViewRight:_finalThankYouLabel] withConstant:24] addToView:self];
+- (void)setupThankYouMainLabelConstraints {
+  [_thankYouMainLabel wtr_constraintHeight:50];
+  [[[[_thankYouMainLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
+  [[[[_thankYouMainLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
+  [[[[self wtr_rightConstraint] toSecondViewRight:_thankYouMainLabel] withConstant:24] addToView:self];
+}
+
+- (void)setupThankYouSetupLabelConstraints {
+  [_thankYouSetupLabel wtr_constraintHeight:30];
+  [[[[_thankYouSetupLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
+  [[[[_thankYouSetupLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
+  [[[[_thankYouSetupLabel wtr_topConstraint] toSecondViewBottom:_thankYouMainLabel] withConstant:8] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {
@@ -250,7 +283,16 @@
   [[[_thankYouButton wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
   [[[[_thankYouButton wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
   [[[[_thankYouButton wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_thankYouButton wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:38] addToView:self];
+  [self setupThankYouButtonTopConstraints:_thankYouSetupLabel];
+}
+
+- (void)setupThankYouButtonTopConstraints:(UIView *)secondViewBottom {
+  if (_thankYouButtonTopConstraint) {
+    [_thankYouButtonTopConstraint removeFromView:self];
+  }
+  
+  _thankYouButtonTopConstraint = [[[_thankYouButton wtr_topConstraint] toSecondViewBottom:secondViewBottom] withConstant:8];
+  [_thankYouButtonTopConstraint addToView:self];
 }
 
 - (void)setupNoThanksButtonConstraints {

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
@@ -1,8 +1,8 @@
 //
-//  WTRCustomThankYou.h
+//  WTRUserCustomThankYou.h
 //  WootricSDK
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+// Copyright (c) 2019 Wootric (https://wootric.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,9 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-@interface WTRCustomThankYou : NSObject
+@interface WTRUserCustomThankYou : NSObject
 
 @property (nonatomic, strong) NSString *thankYouMain;
 @property (nonatomic, strong) NSString *thankYouSetup;
@@ -42,8 +43,11 @@
 @property (nonatomic, strong) NSURL *passiveThankYouLinkURL;
 @property (nonatomic, strong) NSString *promoterThankYouLinkText;
 @property (nonatomic, strong) NSURL *promoterThankYouLinkURL;
+@property (nonatomic, strong) UIColor *backgroundColor;
 
-- (instancetype)initWithCustomThankYou:(NSDictionary *)customThankYou;
+- (BOOL)userCustomThankYouMainPresent;
+- (BOOL)userCustomThankYouSetupPresent;
+- (BOOL)userCustomLinkPresent;
 - (BOOL)hasShareConfiguration;
 
 @end

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
@@ -1,8 +1,8 @@
 //
-//  WTRiPADSocialShareView.h
+//  WTRUserCustomThankYou.h
 //  WootricSDK
 //
-// Copyright (c) 2018 Wootric (https://wootric.com)
+// Copyright (c) 2019 Wootric (https://wootric.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <UIKit/UIKit.h>
-#import "WTRSettings.h"
+#import "WTRUserCustomThankYou.h"
 
-@interface WTRiPADSocialShareView : UIView
+@implementation WTRUserCustomThankYou
 
-- (instancetype)initWithSettings:(WTRSettings *)settings;
-- (void)setupSubviewsConstraints;
-- (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
-- (void)noThankYouButton;
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)text;
-- (void)setThankYouMainDependingOnScore:(int)score;
-- (void)setThankYouSetupDependingOnScore:(int)score;
-- (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;
+- (BOOL)userCustomThankYouMainPresent {
+  if (_thankYouMain || _detractorThankYouMain || _passiveThankYouMain || _promoterThankYouMain) {
+    return YES;
+  }
+  
+  return NO;
+}
+
+- (BOOL)userCustomThankYouSetupPresent {
+  if (_thankYouSetup || _detractorThankYouSetup || _passiveThankYouSetup || _promoterThankYouSetup) {
+    return YES;
+  }
+  
+  return NO;
+}
+
+- (BOOL)userCustomLinkPresent {
+  if (_thankYouLinkText || _detractorThankYouLinkText || _passiveThankYouLinkText || _promoterThankYouLinkText) {
+    return YES;
+  }
+  
+  return NO;
+}
+
+- (BOOL)hasShareConfiguration {
+  return (_promoterThankYouLinkText && _promoterThankYouLinkURL);
+}
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRiPADQuestionView.m
@@ -127,18 +127,15 @@
 }
 
 - (void)setupQuestionLabel {
-  _questionLabel = [UIItems questionLabelWithSettings:_settings
-                                                    andFont:[UIFont systemFontOfSize:18]];
+  _questionLabel = [UIItems questionLabelWithSettings:_settings font:[UIFont systemFontOfSize:18]];
 }
 
 - (void)setupLikelyAnchor {
-  _likelyAnchor = [UIItems likelyAnchorWithSettings:_settings
-                                            andFont:[UIFont italicSystemFontOfSize:12]];
+  _likelyAnchor = [UIItems likelyAnchorWithSettings:_settings font:[UIFont italicSystemFontOfSize:12]];
 }
 
 - (void)setupNotLikelyAnchor {
-  _notLikelyAnchor = [UIItems notLikelyAnchorWithSettings:_settings
-                                                  andFont:[UIFont italicSystemFontOfSize:12]];
+  _notLikelyAnchor = [UIItems notLikelyAnchorWithSettings:_settings font:[UIFont italicSystemFontOfSize:12]];
 }
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
@@ -36,9 +36,8 @@
 @property (nonatomic, strong) UIButton *noThanksButton;
 @property (nonatomic, strong) UIButton *facebookButton;
 @property (nonatomic, strong) UIButton *facebookLikeButton;
-@property (nonatomic, strong) UILabel *finalThankYouLabel;
-@property (nonatomic, strong) UILabel *customThankYouLabel;
-@property (nonatomic, strong) UILabel *socialShareQuestionLabel;
+@property (nonatomic, strong) UILabel *thankYouMainLabel;
+@property (nonatomic, strong) UILabel *thankYouSetupLabel;
 @property (nonatomic, strong) WTRiPADThankYouButton *thankYouButton;
 @property (nonatomic, strong) NSLayoutConstraint *twitterXConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *facebookXConstraint;
@@ -63,8 +62,8 @@
 }
 
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController {
-  [self setupFinalThankYouLabel];
-  [self setupCustomThankYouLabel];
+  [self setupThankYouMainLabel];
+  [self setupThankYouSetupLabel];
   [self setupTwitterButtonWithTargetViewController:viewController];
   [self setupThankYouButtonWithTargetViewController:viewController];
   [self setupNoThanksButtonWithTargetViewController:viewController];
@@ -74,8 +73,8 @@
 }
 
 - (void)setupSubviewsConstraints {
-  [self setupFinalThankYouLabelConstraints];
-  [self setupCustomThankYouLabelConstraints];
+  [self setupThankYouMainLabelConstraints];
+  [self setupThankYouSetupLabelConstraints];
   [self setupThankYouButtonConstraints];
   [self setupNoThanksButtonConstraints];
   [self setupFacebookButtonConstraints];
@@ -89,16 +88,21 @@
   [self addSubview:_facebookButton];
   [self addSubview:_thankYouButton];
   [self addSubview:_noThanksButton];
-  [self addSubview:_finalThankYouLabel];
-  [self addSubview:_customThankYouLabel];
-  [self addSubview:_socialShareQuestionLabel];
+  [self addSubview:_thankYouMainLabel];
+  [self addSubview:_thankYouSetupLabel];
 }
 
-- (void)setThankYouMessageDependingOnScore:(int)score {
-  if ([_settings thankYouMessageDependingOnScore:score]) {
-    _customThankYouLabel.text = [_settings thankYouMessageDependingOnScore:score];
+- (void)setThankYouMainDependingOnScore:(int)score {
+  if ([_settings thankYouMainDependingOnScore:score]) {
+    _thankYouMainLabel.text = [_settings thankYouMainDependingOnScore:score];
+  }
+}
+
+- (void)setThankYouSetupDependingOnScore:(int)score {
+  if ([_settings thankYouSetupDependingOnScore:score]) {
+    _thankYouSetupLabel.text = [_settings thankYouSetupDependingOnScore:score];
   } else {
-    _customThankYouLabel.text = [_settings socialShareQuestionText];
+    _thankYouSetupLabel.hidden = YES;
   }
 }
 
@@ -197,28 +201,26 @@
   _thankYouButton = [[WTRiPADThankYouButton alloc] initWithViewController:viewController];
 }
 
-- (void)setupCustomThankYouLabel {
-  _customThankYouLabel = [UIItems customThankYouLabelWithFont:[UIFont systemFontOfSize:14]];
+- (void)setupThankYouMainLabel {
+  _thankYouMainLabel = [UIItems thankYouMainLabelWithSettings:_settings textColor:[WTRColor iPadQuestionsTextColor] font:[UIFont boldSystemFontOfSize:16]];
 }
 
-- (void)setupFinalThankYouLabel {
-  _finalThankYouLabel = [UIItems finalThankYouLabelWithSettings:_settings
-                                                      textColor:[WTRColor iPadQuestionsTextColor]
-                                                        andFont:[UIFont boldSystemFontOfSize:16]];
+- (void)setupThankYouSetupLabel {
+  _thankYouSetupLabel = [UIItems thankYouSetupLabelWithFont:[UIFont systemFontOfSize:14]];
 }
 
 #pragma mark - Setup Constraints
 
-- (void)setupFinalThankYouLabelConstraints {
-  [[[[_finalThankYouLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
-  [[[[_finalThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[self wtr_rightConstraint] toSecondViewRight:_finalThankYouLabel] withConstant:24] addToView:self];
+- (void)setupThankYouMainLabelConstraints {
+  [[[[_thankYouMainLabel wtr_topConstraint] toSecondViewTop:self] withConstant:16] addToView:self];
+  [[[[_thankYouMainLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
+  [[[[self wtr_rightConstraint] toSecondViewRight:_thankYouMainLabel] withConstant:24] addToView:self];
 }
 
-- (void)setupCustomThankYouLabelConstraints {
-  [[[[_customThankYouLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
-  [[[[_customThankYouLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
-  [[[[_customThankYouLabel wtr_topConstraint] toSecondViewBottom:_finalThankYouLabel] withConstant:12] addToView:self];
+- (void)setupThankYouSetupLabelConstraints {
+  [[[[_thankYouSetupLabel wtr_leftConstraint] toSecondViewLeft:self] withConstant:24] addToView:self];
+  [[[[_thankYouSetupLabel wtr_rightConstraint] toSecondViewRight:self] withConstant:-24] addToView:self];
+  [[[[_thankYouSetupLabel wtr_topConstraint] toSecondViewBottom:_thankYouMainLabel] withConstant:12] addToView:self];
 }
 
 - (void)setupThankYouButtonConstraints {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -195,7 +195,8 @@
   }
   if ([self socialShareAvailableForScore:_currentScore]) {
     [_socialShareView setThankYouButtonTextAndURLDependingOnScore:_currentScore andText:_feedbackText];
-    [_socialShareView setThankYouMessageDependingOnScore:_currentScore];
+    [_socialShareView setThankYouMainDependingOnScore:_currentScore];
+    [_socialShareView setThankYouSetupDependingOnScore:_currentScore];
     [self setupFacebookAndTwitterForScore:_currentScore];
     [self presentSocialShareViewWithScore:_currentScore];
   } else {

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -192,34 +192,50 @@ static id<WTRSurveyDelegate> _delegate = nil;
 
 + (void)setTwitterHandler:(NSString *)twitterHandler {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.twitterHandler = twitterHandler;
+  [apiClient.settings setTwitterHandler:twitterHandler];
 }
 
 + (void)setFacebookPage:(NSURL *)facebookPage {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.facebookPage = facebookPage;
+  [apiClient.settings setFacebookPage:facebookPage];
 }
 
 #pragma mark - Custom Thanks
 
 + (void)setThankYouMessage:(NSString *)thankYouMessage {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setThankYouMessage:thankYouMessage];
+  [self setThankYouMain:thankYouMessage];
 }
 
 + (void)setDetractorThankYouMessage:(NSString *)detractorThankYouMessage {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setDetractorThankYouMessage:detractorThankYouMessage];
+  [self setDetractorThankYouMain:detractorThankYouMessage];
 }
 
 + (void)setPassiveThankYouMessage:(NSString *)passiveThankYouMessage {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPassiveThankYouMessage:passiveThankYouMessage];
+  [self setPassiveThankYouMain:passiveThankYouMessage];
 }
 
 + (void)setPromoterThankYouMessage:(NSString *)promoterThankYouMessage {
+  [self setPromoterThankYouMain:promoterThankYouMessage];
+}
+
++ (void)setThankYouMain:(NSString *)thankYouMain {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPromoterThankYouMessage:promoterThankYouMessage];
+  [apiClient.settings setThankYouMain:thankYouMain];
+}
+
++ (void)setDetractorThankYouMain:(NSString *)detractorThankYouMain {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  [apiClient.settings setDetractorThankYouMain:detractorThankYouMain];
+}
+
++ (void)setPassiveThankYouMain:(NSString *)passiveThankYouMain {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  [apiClient.settings setPassiveThankYouMain:passiveThankYouMain];
+}
+
++ (void)setPromoterThankYouMain:(NSString *)promoterThankYouMain {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  [apiClient.settings setPromoterThankYouMain:promoterThankYouMain];
 }
 
 + (void)setThankYouLinkWithText:(NSString *)thankYouLinkText URL:(NSURL *)thankYouLinkURL {

--- a/WootricSDK/WootricSDKTests/WTRSettingsTests.m
+++ b/WootricSDK/WootricSDKTests/WTRSettingsTests.m
@@ -167,45 +167,40 @@
   XCTAssertEqualObjects(editScoreButtonTitle, @"edit");
 }
 
-- (void)testSocialShareQuestion {
-  NSString *socialShareQuestion = [_settings socialShareQuestionText];
-  XCTAssertEqualObjects(socialShareQuestion, @"Would you be willing to share your positive comments?");
-}
-
 - (void)testSocialShareDecline {
   NSString *socialShareDecline = [_settings socialShareDeclineText];
   XCTAssertEqualObjects(socialShareDecline, @"No thanks...");
 }
 
-- (void)testThankYouMessage {
-  [_settings setThankYouMessage:@"thank you message"];
-  NSString *thankYouMessage = [_settings thankYouMessageDependingOnScore:1];
-  XCTAssertEqualObjects(thankYouMessage, @"thank you message");
-  NSString *thankYouMessageTwo = [_settings thankYouMessageDependingOnScore:8];
-  XCTAssertEqualObjects(thankYouMessageTwo, @"thank you message");
-  NSString *thankYouMessageThree = [_settings thankYouMessageDependingOnScore:10];
-  XCTAssertEqualObjects(thankYouMessageThree, @"thank you message");
+- (void)testThankYouMain {
+  [_settings setThankYouMain:@"thank you message"];
+  NSString *thankYouMain = [_settings thankYouMainDependingOnScore:1];
+  XCTAssertEqualObjects(thankYouMain, @"thank you message");
+  NSString *thankYouMainTwo = [_settings thankYouMainDependingOnScore:8];
+  XCTAssertEqualObjects(thankYouMainTwo, @"thank you message");
+  NSString *thankYouMainThree = [_settings thankYouMainDependingOnScore:10];
+  XCTAssertEqualObjects(thankYouMainThree, @"thank you message");
 }
 
-- (void)testThankYouMessageDetractor {
-  [_settings setThankYouMessage:@"thank you message"];
-  [_settings setDetractorThankYouMessage:@"detractor thank you message"];
-  NSString *thankYouMessage = [_settings thankYouMessageDependingOnScore:1];
-  XCTAssertEqualObjects(thankYouMessage, @"detractor thank you message");
+- (void)testThankYouMainDetractor {
+  [_settings setThankYouMain:@"thank you message"];
+  [_settings setDetractorThankYouMain:@"detractor thank you message"];
+  NSString *thankYouMain = [_settings thankYouMainDependingOnScore:1];
+  XCTAssertEqualObjects(thankYouMain, @"detractor thank you message");
 }
 
-- (void)testThankYouMessagePassive {
-  [_settings setThankYouMessage:@"thank you message"];
-  [_settings setPassiveThankYouMessage:@"passive thank you message"];
-  NSString *thankYouMessage = [_settings thankYouMessageDependingOnScore:8];
-  XCTAssertEqualObjects(thankYouMessage, @"passive thank you message");
+- (void)testThankYouMainPassive {
+  [_settings setThankYouMain:@"thank you message"];
+  [_settings setPassiveThankYouMain:@"passive thank you message"];
+  NSString *thankYouMain = [_settings thankYouMainDependingOnScore:8];
+  XCTAssertEqualObjects(thankYouMain, @"passive thank you message");
 }
 
-- (void)testThankYouMessagePromoter {
-  [_settings setThankYouMessage:@"thank you message"];
-  [_settings setPromoterThankYouMessage:@"promoter thank you message"];
-  NSString *thankYouMessage = [_settings thankYouMessageDependingOnScore:10];
-  XCTAssertEqualObjects(thankYouMessage, @"promoter thank you message");
+- (void)testThankYouMainPromoter {
+  [_settings setThankYouMain:@"thank you message"];
+  [_settings setPromoterThankYouMain:@"promoter thank you message"];
+  NSString *thankYouMain = [_settings thankYouMainDependingOnScore:10];
+  XCTAssertEqualObjects(thankYouMain, @"promoter thank you message");
 }
 
 - (void)testThankYouLinkWithURL {


### PR DESCRIPTION
This PR adds the required functionality to pull values of the 3rd screen settings from the server. PR is big and has a lot of different setups, so please test thoroughly.

## Changes
- Update demo app with button to force survey
- Refactor code to use values retrieved from the server when present
- Update tests

## Test

There are lots of combinations of how this can work, so please test each one of them to make sure nothing is being missed. The third screen setup of the Settings will be your friend here, since that's where all the changes happen, so it's useful to check that whatever is being shown in mobile, should match what is shown in the Preview there.

![Screen Shot 2019-10-10 at 3 11 50 AM](https://user-images.githubusercontent.com/1431421/66550944-0ce54e00-eb0c-11e9-93ab-79764c27d781.png)

Like I mentioned there are many combinations, this list should help with testing:

- [x] Empty values on database, empty values on code: should show the default message.
- [x] Empty values on database, value set on code: should show the value set by code.
- [x] Value set on database, empty values on code: should show the value set on the db.
- [x] Value set on database, value set on code: should show the value set by code.
- [x] Works for all scores (negative, neutral, positive)
- [x] If using `Unique by score`, it shows default value when value is not set (e.g. promoter thank you message is set, but empty for passives and detractors
- [x] Works on iPad
- [x] Works on different account types (NPS, CES, CSAT)
