### PR TITLE
Add support for checkboxes on third screen of the admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.0 (2019-12-04)
+
+### Changes:
+
+- Add support of admin panel values for adding email, score and comment to thank you link
+
 ## 0.15.0 (2019-10-18)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.15.0"
+	pod "WootricSDK", "~> 0.16.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.15.0'
+  s.version  = '0.16.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.0</string>
+	<string>0.16.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.h
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.h
@@ -42,6 +42,18 @@
 @property (nonatomic, strong) NSURL *passiveThankYouLinkURL;
 @property (nonatomic, strong) NSString *promoterThankYouLinkText;
 @property (nonatomic, strong) NSURL *promoterThankYouLinkURL;
+@property (nonatomic, assign) int isEmailInURL;
+@property (nonatomic, assign) int isDetractorEmailInURL;
+@property (nonatomic, assign) int isPassiveEmailInURL;
+@property (nonatomic, assign) int isPromoterEmailInURL;
+@property (nonatomic, assign) int isScoreInURL;
+@property (nonatomic, assign) int isDetractorScoreInURL;
+@property (nonatomic, assign) int isPassiveScoreInURL;
+@property (nonatomic, assign) int isPromoterScoreInURL;
+@property (nonatomic, assign) int isCommentInURL;
+@property (nonatomic, assign) int isDetractorCommentInURL;
+@property (nonatomic, assign) int isPassiveCommentInURL;
+@property (nonatomic, assign) int isPromoterCommentInURL;
 
 - (instancetype)initWithCustomThankYou:(NSDictionary *)customThankYou;
 - (BOOL)hasShareConfiguration;

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.m
@@ -49,13 +49,32 @@
       if (thankYouLinks[@"thank_you_link_text"] && thankYouLinks[@"thank_you_link_url"]) {
         _thankYouLinkText = thankYouLinks[@"thank_you_link_text"];
         _thankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url"]];
+        _isEmailInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_email_param_to_url"] integerValue];
+        _isScoreInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_score_param_to_url"] integerValue];
+        _isCommentInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_comment_param_to_url"] integerValue];
       } else {
+        NSDictionary *thankYouLinkUrlSettingsList = thankYouLinks[@"thank_you_link_url_settings_list"];
+        NSDictionary *detractorThankYouLinkUrlSettings = thankYouLinkUrlSettingsList[@"detractor_thank_you_link_url_settings"];
+        NSDictionary *passiveThankYouLinkUrlSettings = thankYouLinkUrlSettingsList[@"passive_thank_you_link_url_settings"];
+        NSDictionary *promoterThankYouLinkUrlSettings = thankYouLinkUrlSettingsList[@"promoter_thank_you_link_url_settings"];
+        
         _detractorThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"detractor_thank_you_link_text"];
         _detractorThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"detractor_thank_you_link_url"]];
+        _isDetractorEmailInURL = [detractorThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
+        _isDetractorScoreInURL = [detractorThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
+        _isDetractorCommentInURL = [detractorThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
+        
         _passiveThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"passive_thank_you_link_text"];
         _passiveThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"passive_thank_you_link_url"]];
+        _isPassiveEmailInURL = [passiveThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
+        _isPassiveScoreInURL = [passiveThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
+        _isPassiveCommentInURL = [passiveThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
+        
         _promoterThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"promoter_thank_you_link_text"];
         _promoterThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"promoter_thank_you_link_url"]];
+        _isPromoterEmailInURL = [promoterThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
+        _isPromoterScoreInURL = [promoterThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
+        _isPromoterCommentInURL = [promoterThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
       }
     }
   }

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -102,10 +102,17 @@
 - (void)setPassiveThankYouLinkWithText:(NSString *)passiveThankYouLinkText URL:(NSURL *)passiveThankYouLinkURL;
 - (void)setPromoterThankYouLinkWithText:(NSString *)promoterThankYouLinkText URL:(NSURL *)promoterThankYouLinkURL;
 
+- (void)setEmailInURL:(int)emailInURL;
+- (void)setPromoterEmailInURL:(int)promoterEmailInURL passiveEmailInURL:(int)passiveEmailInURL detractorEmailInURL:(int)detractorEmailInURL;
+- (void)setScoreInURL:(int)scoreInURL;
+- (void)setPromoterScoreInURL:(int)promoterScoreInURL passiveScoreInURL:(int)passiveScoreInURL detractorScoreInURL:(int)detractorScoreInURL;
+- (void)setCommentInURL:(int)commentInURL;
+- (void)setPromoterCommentInURL:(int)promoterCommentInURL passiveCommentInURL:(int)passiveCommentInURL detractorCommentInURL:(int)detractorCommentInURL;
+
 - (NSString *)thankYouMainDependingOnScore:(int)score;
 - (NSString *)thankYouSetupDependingOnScore:(int)score;
 - (NSString *)thankYouLinkTextDependingOnScore:(int)score;
-- (NSURL *)thankYouLinkURLDependingOnScore:(int)score andText:(NSString *)text;
+- (NSURL *)thankYouLinkURLDependingOnScore:(int)score text:(NSString *)text email:(NSString *)email;
 - (BOOL)thankYouLinkConfiguredForScore:(int)score;
 
 - (void)setTwitterHandler:(NSString *)twitterHandler;

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -46,7 +46,6 @@
 @implementation WTRSettings
 
 - (instancetype)init {
-    
   if (self = [super init]) {
     _setDefaultAfterSurvey = YES;
     _surveyedDefaultDuration = 90;
@@ -378,6 +377,36 @@
   _userCustomThankYou.promoterThankYouLinkURL = promoterThankYouLinkURL;
 }
 
+- (void)setEmailInURL:(int)emailInURL {
+  _userCustomThankYou.isEmailInURL = emailInURL;
+}
+
+- (void)setPromoterEmailInURL:(int)promoterEmailInURL passiveEmailInURL:(int)passiveEmailInURL detractorEmailInURL:(int)detractorEmailInURL  {
+  _userCustomThankYou.isDetractorEmailInURL = detractorEmailInURL;
+  _userCustomThankYou.isPassiveEmailInURL = passiveEmailInURL;
+  _userCustomThankYou.isPromoterEmailInURL = promoterEmailInURL;
+}
+
+- (void)setScoreInURL:(int)scoreInURL {
+  _userCustomThankYou.isScoreInURL = scoreInURL;
+}
+
+- (void)setPromoterScoreInURL:(int)promoterScoreInURL passiveScoreInURL:(int)passiveScoreInURL detractorScoreInURL:(int)detractorScoreInURL  {
+  _userCustomThankYou.isDetractorScoreInURL = detractorScoreInURL;
+  _userCustomThankYou.isPassiveScoreInURL = passiveScoreInURL;
+  _userCustomThankYou.isPromoterScoreInURL = promoterScoreInURL;
+}
+
+- (void)setCommentInURL:(int)commentInURL {
+  _userCustomThankYou.isCommentInURL = commentInURL;
+}
+
+- (void)setPromoterCommentInURL:(int)promoterCommentInURL passiveCommentInURL:(int)passiveCommentInURL detractorCommentInURL:(int)detractorCommentInURL  {
+  _userCustomThankYou.isDetractorCommentInURL = detractorCommentInURL;
+  _userCustomThankYou.isPassiveCommentInURL = passiveCommentInURL;
+  _userCustomThankYou.isPromoterCommentInURL = promoterCommentInURL;
+}
+
 - (void)setCustomFollowupQuestionForPromoter:(NSString *)promoterQuestion passive:(NSString *)passiveQuestion detractor:(NSString *)detractorQuestion {
   _userCustomMessages.promoterQuestion = promoterQuestion;
   _userCustomMessages.passiveQuestion = passiveQuestion;
@@ -438,27 +467,15 @@
   return nil;
 }
 
-- (NSURL *)thankYouLinkURLDependingOnScore:(int)score andText:(NSString *)text {
+- (NSURL *)thankYouLinkURLDependingOnScore:(int)score text:(NSString *)text email:(NSString *)email {
   if ([self negativeTypeScore:score] && (_customThankYou.detractorThankYouLinkURL || _userCustomThankYou.detractorThankYouLinkURL)) {
-    if (_passScoreAndTextToURL) {
-      return [self detractorThankYouLinkURLWithScore:score text:text];
-    }
-    return [self detractorThankYouLinkURL];
+    return [self detractorThankYouLinkURLWithScore:score text:text email:email];
   } else if ([self neutralTypeScore:score] && (_customThankYou.passiveThankYouLinkURL || _userCustomThankYou.passiveThankYouLinkURL)) {
-    if (_passScoreAndTextToURL) {
-      return [self passiveThankYouLinkURLWithScore:score text:text];
-    }
-    return [self passiveThankYouLinkURL];;
+    return [self passiveThankYouLinkURLWithScore:score text:text email:email];
   } else if ([self positiveTypeScore:score] && (_customThankYou.promoterThankYouLinkURL || _userCustomThankYou.promoterThankYouLinkURL)) {
-    if (_passScoreAndTextToURL) {
-      return [self promoterThankYouLinkURLWithScore:score text:text];
-    }
-    return [self promoterThankYouLinkURL];
+    return [self promoterThankYouLinkURLWithScore:score text:text email:email];
   } else if (_customThankYou.thankYouLinkURL || _userCustomThankYou.thankYouLinkURL) {
-    if (_passScoreAndTextToURL) {
-      return [self thankYouLinkURLWithScore:score text:text];
-    }
-    return [self thankYouLinkURL];
+    return [self thankYouLinkURLWithScore:score text:text email:email];
   }
   
   return nil;
@@ -479,6 +496,144 @@
   }
   
   return NO;
+}
+
+- (int)thankYouLinkShouldIncludeEmailDependingOnScore:(int)score {
+  if ([self negativeTypeScore:score] && (_customThankYou.isDetractorEmailInURL == 1 || _userCustomThankYou.isDetractorEmailInURL == 1)) {
+    return [self isDetractorEmailInURL];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.isPassiveEmailInURL == 1 || _userCustomThankYou.isPassiveEmailInURL == 1)) {
+    return [self isPassiveEmailInURL];
+  } else if ([self positiveTypeScore:score] && (_customThankYou.isPromoterEmailInURL == 1 || _userCustomThankYou.isPromoterEmailInURL == 1)) {
+    return [self isPromoterEmailInURL];
+  } else if (_customThankYou.isEmailInURL == 1 || _userCustomThankYou.isEmailInURL == 1) {
+    return [self isEmailInURL];
+  }
+  
+  return -1;
+}
+
+- (int)thankYouLinkShouldIncludeScoreDependingOnScore:(int)score {
+  if ([self negativeTypeScore:score] && (_customThankYou.isDetractorScoreInURL == 1 || _userCustomThankYou.isDetractorScoreInURL == 1)) {
+    return [self isDetractorScoreInURL];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.isPassiveScoreInURL == 1 || _userCustomThankYou.isDetractorScoreInURL == 1)) {
+    return [self isPassiveScoreInURL];
+  } else if ([self positiveTypeScore:score] && (_customThankYou.isPromoterScoreInURL == 1 || _userCustomThankYou.isPromoterScoreInURL == 1)) {
+    return [self isPromoterScoreInURL];
+  } else if (_customThankYou.isScoreInURL == 1 || _userCustomThankYou.isScoreInURL == 1) {
+    return [self isScoreInURL];
+  }
+  
+  return -1;
+}
+
+- (int)thankYouLinkShouldIncludeCommentDependingOnScore:(int)score {
+  if ([self negativeTypeScore:score] && (_customThankYou.isDetractorCommentInURL == 1 || _userCustomThankYou.isDetractorCommentInURL == 1)) {
+    return [self isDetractorCommentInURL];
+  } else if ([self neutralTypeScore:score] && (_customThankYou.isPassiveCommentInURL == 1 || _userCustomThankYou.isPassiveCommentInURL) == 1) {
+    return [self isPassiveCommentInURL];
+  } else if ([self positiveTypeScore:score] && (_customThankYou.isPromoterCommentInURL == 1 || _userCustomThankYou.isPromoterCommentInURL == 1)) {
+    return [self isPromoterCommentInURL];
+  } else if (_customThankYou.isCommentInURL == 1 || _userCustomThankYou.isCommentInURL == 1) {
+    return [self isCommentInURL];
+  }
+  
+  return -1;
+}
+
+- (int)isDetractorEmailInURL {
+  if (_userCustomThankYou.isDetractorEmailInURL != -1) {
+    return _userCustomThankYou.isDetractorEmailInURL;
+  }
+  
+  return _customThankYou.isDetractorEmailInURL;
+}
+
+- (int)isPassiveEmailInURL {
+  if (_userCustomThankYou.isPassiveEmailInURL != -1) {
+    return _userCustomThankYou.isPassiveEmailInURL;
+  }
+  
+  return _customThankYou.isPassiveEmailInURL;
+}
+
+- (int)isPromoterEmailInURL {
+  if (_userCustomThankYou.isPromoterEmailInURL != -1) {
+    return _userCustomThankYou.isPromoterEmailInURL;
+  }
+  
+  return _customThankYou.isPromoterEmailInURL;
+}
+
+- (int)isEmailInURL {
+  if (_userCustomThankYou.isEmailInURL != -1) {
+    return _userCustomThankYou.isEmailInURL;
+  }
+  
+  return _customThankYou.isEmailInURL;
+}
+
+- (int)isDetractorScoreInURL {
+  if (_userCustomThankYou.isDetractorScoreInURL != -1) {
+    return _userCustomThankYou.isDetractorScoreInURL;
+  }
+  
+  return _customThankYou.isDetractorScoreInURL;
+}
+
+- (int)isPassiveScoreInURL {
+  if (_userCustomThankYou.isPassiveScoreInURL != -1) {
+    return _userCustomThankYou.isPassiveScoreInURL;
+  }
+  
+  return _customThankYou.isPassiveScoreInURL;
+}
+
+- (int)isPromoterScoreInURL {
+  if (_userCustomThankYou.isPromoterScoreInURL != -1) {
+    return _userCustomThankYou.isPromoterScoreInURL;
+  }
+  
+  return _customThankYou.isPromoterScoreInURL;
+}
+
+- (int)isScoreInURL {
+  if (_userCustomThankYou.isScoreInURL != -1) {
+    return _userCustomThankYou.isScoreInURL;
+  }
+  
+  return _customThankYou.isScoreInURL;
+}
+
+- (int)isDetractorCommentInURL {
+  if (_userCustomThankYou.isDetractorCommentInURL != -1) {
+    return _userCustomThankYou.isDetractorCommentInURL;
+  }
+  
+  return _customThankYou.isDetractorCommentInURL;
+}
+
+- (int)isPassiveCommentInURL {
+  if (_userCustomThankYou.isPassiveCommentInURL != -1) {
+    return _userCustomThankYou.isPassiveCommentInURL;
+  }
+  
+  return _customThankYou.isPassiveCommentInURL;
+}
+
+- (int)isPromoterCommentInURL {
+  if (_userCustomThankYou.isPromoterCommentInURL != -1) {
+    return _userCustomThankYou.isPromoterCommentInURL;
+  }
+  
+  return _customThankYou.isPromoterCommentInURL;
+}
+
+- (int)isCommentInURL {
+  if (_userCustomThankYou.isCommentInURL != -1) {
+    return _userCustomThankYou.isCommentInURL;
+  }
+  
+  return _customThankYou.isCommentInURL;
 }
 
 - (NSString *)detractorThankYouMain {
@@ -609,34 +764,34 @@
   return _customThankYou.thankYouLinkURL;
 }
 
-- (NSURL *)detractorThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+- (NSURL *)detractorThankYouLinkURLWithScore:(int)score text:(NSString *)text email:(NSString *)email {
   if (_userCustomThankYou.detractorThankYouLinkURL) {
-    return [self url:_userCustomThankYou.detractorThankYouLinkURL withScore:score andText:text];
+    return [self url:_userCustomThankYou.detractorThankYouLinkURL withScore:score comment:text email:email];
   }
   
-  return [self url:_customThankYou.detractorThankYouLinkURL withScore:score andText:text];
+  return [self url:_customThankYou.detractorThankYouLinkURL withScore:score comment:text email:email];
 }
 
-- (NSURL *)passiveThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+- (NSURL *)passiveThankYouLinkURLWithScore:(int)score text:(NSString *)text email:(NSString *)email {
   if (_userCustomThankYou.passiveThankYouLinkURL) {
-    return [self url:_userCustomThankYou.passiveThankYouLinkURL withScore:score andText:text];
+    return [self url:_userCustomThankYou.passiveThankYouLinkURL withScore:score comment:text email:email];
   }
   
-  return [self url:_customThankYou.passiveThankYouLinkURL withScore:score andText:text];
+  return [self url:_customThankYou.passiveThankYouLinkURL withScore:score comment:text email:email];
 }
-- (NSURL *)promoterThankYouLinkURLWithScore:(int)score text:(NSString *)text {
+- (NSURL *)promoterThankYouLinkURLWithScore:(int)score text:(NSString *)text email:(NSString *)email {
   if (_userCustomThankYou.promoterThankYouLinkURL) {
-    return [self url:_userCustomThankYou.promoterThankYouLinkURL withScore:score andText:text];
+    return [self url:_userCustomThankYou.promoterThankYouLinkURL withScore:score comment:text email:email];
   }
   
-  return [self url:_customThankYou.promoterThankYouLinkURL withScore:score andText:text];
+  return [self url:_customThankYou.promoterThankYouLinkURL withScore:score comment:text email:email];
 }
-- (NSURL *)thankYouLinkURLWithScore:(int)score text:(NSString *)text {
+- (NSURL *)thankYouLinkURLWithScore:(int)score text:(NSString *)text email:(NSString *)email {
   if (_userCustomThankYou.thankYouLinkURL) {
-    return [self url:_userCustomThankYou.thankYouLinkURL withScore:score andText:text];
+    return [self url:_userCustomThankYou.thankYouLinkURL withScore:score comment:text email:email];
   }
   
-  return [self url:_customThankYou.thankYouLinkURL withScore:score andText:text];
+  return [self url:_customThankYou.thankYouLinkURL withScore:score comment:text email:email];
 }
 
 - (BOOL)detractorOrDefaultURL {
@@ -770,20 +925,42 @@
   return !([[_endUserEmail stringByTrimmingCharactersInSet:set] length] == 0);
 }
 
-- (NSURL *)url:(NSURL *)baseUrl withScore:(int)score andText:(NSString *)text {
-  NSString *paramsString;
-  NSString *escapedText = [text stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+- (NSURL *)url:(NSURL *)baseUrl withScore:(int)score comment:(NSString *)comment email:(NSString *)email {
+  NSMutableString *paramsString = [NSMutableString new];
+  NSString *escapedText = [comment stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
   
   if (!escapedText) {
     escapedText = @"";
   }
   
-  if ([[baseUrl absoluteString] rangeOfString:@"?"].location == NSNotFound) {
-    paramsString = [NSString stringWithFormat:@"?wootric_score=%d&wootric_text=%@", score, escapedText];
-    return [NSURL URLWithString:paramsString relativeToURL:baseUrl];
+  if ([self thankYouLinkShouldIncludeEmailDependingOnScore:score] == 1) {
+    [paramsString appendString:[NSString stringWithFormat:@"wootric_email=%@", email]];
+  }
+  
+  if ([self thankYouLinkShouldIncludeScoreDependingOnScore:score] == 1) {
+    if (paramsString.length == 0) {
+      [paramsString appendString:[NSString stringWithFormat:@"wootric_score=%i", score]];
+    } else {
+      [paramsString appendString:[NSString stringWithFormat:@"&wootric_score=%i", score]];
+    }
+  }
+  
+  if ([self thankYouLinkShouldIncludeCommentDependingOnScore:score] == 1) {
+    if (paramsString.length == 0) {
+      [paramsString appendString:[NSString stringWithFormat:@"wootric_comment=%@", escapedText]];
+    } else {
+      [paramsString appendString:[NSString stringWithFormat:@"&wootric_comment=%@", escapedText]];
+    }
+  }
+  
+  if (paramsString.length > 0) {
+    if ([[baseUrl absoluteString] rangeOfString:@"?"].location == NSNotFound) {
+      return [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", baseUrl, paramsString]];
+    } else {
+      return [NSURL URLWithString:[NSString stringWithFormat:@"%@&%@", baseUrl, paramsString]];
+    }
   } else {
-    paramsString = [NSString stringWithFormat:@"&wootric_score=%d&wootric_text=%@", score, escapedText];
-    return [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", baseUrl, paramsString]];
+    return baseUrl;
   }
 }
 

--- a/WootricSDK/WootricSDK/WTRSocialShareView.h
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.h
@@ -30,7 +30,7 @@
 - (instancetype)initWithSettings:(WTRSettings *)settings;
 - (void)setupSubviewsConstraints;
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)feedbackText;
+- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score text:(NSString *)feedbackText;
 - (void)setThankYouMainDependingOnScore:(int)score;
 - (void)setThankYouSetupDependingOnScore:(int)score;
 - (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;

--- a/WootricSDK/WootricSDK/WTRSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRSocialShareView.m
@@ -64,9 +64,9 @@
   return self;
 }
 
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)feedbackText{
+- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score text:(NSString *)feedbackText {
   NSString *text = [_settings thankYouLinkTextDependingOnScore:score];
-  NSURL *url = [_settings thankYouLinkURLDependingOnScore:score andText:feedbackText];
+  NSURL *url = [_settings thankYouLinkURLDependingOnScore:score text:feedbackText email:_settings.endUserEmail];
 
   if (!text || !url) {
     _thankYouButton.hidden = YES;

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -346,7 +346,7 @@
 
 - (void)presentSocialShareViewWithScore:(int)score {
   NSString *text = [_feedbackView feedbackText];
-  [_socialShareView setThankYouButtonTextAndURLDependingOnScore:score andText:text];
+  [_socialShareView setThankYouButtonTextAndURLDependingOnScore:score text:text];
   [_socialShareView setThankYouMainDependingOnScore:score];
   [_socialShareView setThankYouSetupDependingOnScore:score];
   [self setQuestionViewVisible:NO andFeedbackViewVisible:NO];

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
@@ -44,6 +44,18 @@
 @property (nonatomic, strong) NSString *promoterThankYouLinkText;
 @property (nonatomic, strong) NSURL *promoterThankYouLinkURL;
 @property (nonatomic, strong) UIColor *backgroundColor;
+@property (nonatomic, assign) int isEmailInURL;
+@property (nonatomic, assign) int isDetractorEmailInURL;
+@property (nonatomic, assign) int isPassiveEmailInURL;
+@property (nonatomic, assign) int isPromoterEmailInURL;
+@property (nonatomic, assign) int isScoreInURL;
+@property (nonatomic, assign) int isDetractorScoreInURL;
+@property (nonatomic, assign) int isPassiveScoreInURL;
+@property (nonatomic, assign) int isPromoterScoreInURL;
+@property (nonatomic, assign) int isCommentInURL;
+@property (nonatomic, assign) int isDetractorCommentInURL;
+@property (nonatomic, assign) int isPassiveCommentInURL;
+@property (nonatomic, assign) int isPromoterCommentInURL;
 
 - (BOOL)userCustomThankYouMainPresent;
 - (BOOL)userCustomThankYouSetupPresent;

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
@@ -26,6 +26,25 @@
 
 @implementation WTRUserCustomThankYou
 
+- (instancetype)init {
+  if (self = [super init]) {
+    _isEmailInURL = -1;
+    _isDetractorEmailInURL = -1;
+    _isPassiveEmailInURL = -1;
+    _isPromoterEmailInURL = -1;
+    _isScoreInURL = -1;
+    _isDetractorScoreInURL = -1;
+    _isPassiveScoreInURL = -1;
+    _isPromoterScoreInURL = -1;
+    _isCommentInURL = -1;
+    _isDetractorCommentInURL = -1;
+    _isPassiveCommentInURL = -1;
+    _isPromoterCommentInURL = -1;
+  }
+  
+  return self;
+}
+
 - (BOOL)userCustomThankYouMainPresent {
   if (_thankYouMain || _detractorThankYouMain || _passiveThankYouMain || _promoterThankYouMain) {
     return YES;

--- a/WootricSDK/WootricSDK/WTRiPADSocialShareView.h
+++ b/WootricSDK/WootricSDK/WTRiPADSocialShareView.h
@@ -31,7 +31,7 @@
 - (void)setupSubviewsConstraints;
 - (void)initializeSubviewsWithTargetViewController:(UIViewController *)viewController;
 - (void)noThankYouButton;
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)text;
+- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score text:(NSString *)text;
 - (void)setThankYouMainDependingOnScore:(int)score;
 - (void)setThankYouSetupDependingOnScore:(int)score;
 - (void)displayShareButtonsWithTwitterAvailable:(BOOL)twitterAvailable andFacebookAvailable:(BOOL)facebookAvailable;

--- a/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
+++ b/WootricSDK/WootricSDK/WTRiPADSocialShareView.m
@@ -106,9 +106,9 @@
   }
 }
 
-- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score andText:(NSString *)text {
+- (void)setThankYouButtonTextAndURLDependingOnScore:(int)score text:(NSString *)text{
   NSString *thankYouText = [_settings thankYouLinkTextDependingOnScore:score];
-  NSURL *url = [_settings thankYouLinkURLDependingOnScore:score andText:text];
+  NSURL *url = [_settings thankYouLinkURLDependingOnScore:score text:text email:_settings.endUserEmail];
 
   [_thankYouButton setText:thankYouText andURL:url];
 }

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -194,7 +194,7 @@
     _feedbackText = [_feedbackView feedbackText];
   }
   if ([self socialShareAvailableForScore:_currentScore]) {
-    [_socialShareView setThankYouButtonTextAndURLDependingOnScore:_currentScore andText:_feedbackText];
+    [_socialShareView setThankYouButtonTextAndURLDependingOnScore:_currentScore text:_feedbackText];
     [_socialShareView setThankYouMainDependingOnScore:_currentScore];
     [_socialShareView setThankYouSetupDependingOnScore:_currentScore];
     [self setupFacebookAndTwitterForScore:_currentScore];

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -210,6 +210,48 @@
 + (void)setPromoterThankYouLinkWithText:(NSString *)promoterThankYouLinkText URL:(NSURL *)promoterThankYouLinkURL;
 
 /**
+ @discussion Specifies if the email should be passed in the thank you link URL, as `wootric_email`
+ @param emailInURL Boolean.
+ */
++ (void)passEmailInURL:(BOOL)emailInURL;
+
+/**
+ @discussion Specifies if the email should be passed in the thank you link URL for each type of response, as `wootric_email`
+ @param promoterEmailInURL Boolean.
+ @param passiveEmailInURL Boolean.
+ @param detractorEmailInURL Boolean.
+ */
++ (void)passPromoterEmailInURL:(BOOL)promoterEmailInURL passiveEmailInURL:(BOOL)passiveEmailInURL detractorEmailInURL:(BOOL)detractorEmailInURL;
+
+/**
+ @discussion Specifies if the score should be passed in the thank you link URL, as `wootric_score`
+ @param scoreInURL Boolean.
+ */
++ (void)passScoreInURL:(BOOL)scoreInURL;
+
+/**
+ @discussion Specifies if the score should be passed in the thank you link URL for each type of response, as `wootric_score`
+ @param promoterScoreInURL Boolean.
+ @param passiveScoreInURL Boolean.
+ @param detractorScoreInURL Boolean.
+ */
++ (void)passPromoterScoreInURL:(BOOL)promoterScoreInURL passiveScoreInURL:(BOOL)passiveScoreInURL detractorScoreInURL:(BOOL)detractorScoreInURL;
+
+/**
+ @discussion Specifies if the feedback should be passed in the thank you link URL, as `wootric_comment`
+ @param commentInURL Boolean.
+ */
++ (void)passCommentInURL:(BOOL)commentInURL;
+
+/**
+ @discussion Specifies if the feedback should be passed in the thank you link URL for each type of response, as `wootric_comment`
+ @param promoterCommentInURL Boolean.
+ @param passiveCommentInURL Boolean.
+ @param detractorCommentInURL Boolean.
+ */
++ (void)passPromoterCommentInURL:(BOOL)promoterCommentInURL passiveCommentInURL:(BOOL)passiveCommentInURL detractorCommentInURL:(BOOL)detractorCommentInURL;
+
+/**
  @discussion This method allows you to set custom placeholder text in feedback text view for each type of end user. Be advised that this setting takes precedence over values set in Wootric's from admin panel.
  @param promoterPlaceholder NSString placeholder for promoters (score 9-10).
  @param passivePlaceholder NSString placeholder for passives (score 7-8).

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -150,9 +150,108 @@ static id<WTRSurveyDelegate> _delegate = nil;
   apiClient.settings.skipFeedbackScreen = flag;
 }
 
-+ (void)passScoreAndTextToURL:(BOOL)flag {
++ (void) passScoreAndTextToURL:(BOOL)flag {
   WTRApiClient *apiClient = [WTRApiClient sharedInstance];
   apiClient.settings.passScoreAndTextToURL = flag;
+}
+
++ (void)passEmailInURL:(BOOL)emailInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  if (emailInURL) {
+    [apiClient.settings setEmailInURL:1];
+  } else {
+    [apiClient.settings setEmailInURL:0];
+  }
+}
+
++ (void)passPromoterEmailInURL:(BOOL)promoterEmailInURL passiveEmailInURL:(BOOL)passiveEmailInURL detractorEmailInURL:(BOOL)detractorEmailInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  int promoter = -1;
+  int passive = -1;
+  int detractor = -1;
+  if (promoterEmailInURL) {
+    promoter = 1;
+  } else {
+    promoter = 0;
+  }
+  if (passiveEmailInURL) {
+    passive = 1;
+  } else {
+    passive = 0;
+  }
+  if (detractorEmailInURL) {
+    detractor = 1;
+  } else {
+    detractor = 0;
+  }
+  
+  [apiClient.settings setPromoterEmailInURL:promoter passiveEmailInURL:passive detractorEmailInURL:detractor];
+}
+
++ (void)passScoreInURL:(BOOL)scoreInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  if (scoreInURL) {
+    [apiClient.settings setScoreInURL:1];
+  } else {
+    [apiClient.settings setScoreInURL:0];
+  }
+}
+
++ (void)passPromoterScoreInURL:(BOOL)promoterScoreInURL passiveScoreInURL:(BOOL)passiveScoreInURL detractorScoreInURL:(BOOL)detractorScoreInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  int promoter = -1;
+  int passive = -1;
+  int detractor = -1;
+  if (promoterScoreInURL) {
+    promoter = 1;
+  } else {
+    promoter = 0;
+  }
+  if (passiveScoreInURL) {
+    passive = 1;
+  } else {
+    passive = 0;
+  }
+  if (detractorScoreInURL) {
+    detractor = 1;
+  } else {
+    detractor = 0;
+  }
+  
+  [apiClient.settings setPromoterScoreInURL:promoter passiveScoreInURL:passive detractorScoreInURL:detractor];
+}
+
++ (void)passCommentInURL:(BOOL)commentInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  if (commentInURL) {
+    [apiClient.settings setCommentInURL:1];
+  } else {
+    [apiClient.settings setCommentInURL:0];
+  }
+}
+
++ (void)passPromoterCommentInURL:(BOOL)promoterCommentInURL passiveCommentInURL:(BOOL)passiveCommentInURL detractorCommentInURL:(BOOL)detractorCommentInURL {
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  int promoter = -1;
+  int passive = -1;
+  int detractor = -1;
+  if (promoterCommentInURL) {
+    promoter = 1;
+  } else {
+    promoter = 0;
+  }
+  if (passiveCommentInURL) {
+    passive = 1;
+  } else {
+    passive = 0;
+  }
+  if (detractorCommentInURL) {
+    detractor = 1;
+  } else {
+    detractor = 0;
+  }
+  
+  [apiClient.settings setPromoterCommentInURL:promoter passiveCommentInURL:passive detractorCommentInURL:detractor];
 }
 
 + (void)showSurveyInViewController:(UIViewController *)viewController {

--- a/WootricSDK/WootricSDKTests/WTRSettingsTests.m
+++ b/WootricSDK/WootricSDKTests/WTRSettingsTests.m
@@ -86,6 +86,330 @@
   XCTAssertEqualObjects(followupQuestion, @"promoter question");
 }
 
+- (void)testThankYouLinkWithEmailScoreCommentForDetractor {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"detractor_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                      @"add_comment_param_to_url": @1,
+                                                                                      @"add_email_param_to_url": @1,
+                                                                                      @"add_score_param_to_url": @1
+                                                                                      }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://detractor.com?wootric_email=testing@wootric.com&wootric_score=1&wootric_comment=Not%20good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"Not good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Detractor thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreCommentForPassives {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"passive_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://passive.com?wootric_email=testing@wootric.com&wootric_score=8&wootric_comment=Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:8];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Passive thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+
+- (void)testThankYouLinkWithEmailScoreCommentForPromoters {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_email=testing@wootric.com&wootric_score=10&wootric_comment=Very%20Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreForDetractors {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"detractor_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @0,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://detractor.com?wootric_email=testing@wootric.com&wootric_score=1"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"Not good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Detractor thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreForPassives {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"passive_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @0,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://passive.com?wootric_email=testing@wootric.com&wootric_score=8"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:8];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Passive thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreForProtomer {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @0,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_email=testing@wootric.com&wootric_score=10"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailCommentForDetractor {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"detractor_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @0
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://detractor.com?wootric_email=testing@wootric.com&wootric_comment=Not%20good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"Not good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Detractor thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailCommentForPassive {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"passive_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @0
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://passive.com?wootric_email=testing@wootric.com&wootric_comment=Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:8];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Passive thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailCommentForPromoter {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @0
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_email=testing@wootric.com&wootric_comment=Very%20Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScoreCommentForDetractor {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"detractor_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @0,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://detractor.com?wootric_score=1&wootric_comment=Not%20good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"Not good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Detractor thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScoreCommentForPassive {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"passive_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @0,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://passive.com?wootric_score=8&wootric_comment=Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:8];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Passive thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScoreCommentForPromoter {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @0,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_score=10&wootric_comment=Very%20Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmail {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @0,
+                                                                                       @"add_email_param_to_url": @1,
+                                                                                       @"add_score_param_to_url": @0
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_email=testing@wootric.com"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScore {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @0,
+                                                                                       @"add_email_param_to_url": @0,
+                                                                                       @"add_score_param_to_url": @1
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_score=10"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithComment {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouWithKey:@"promoter_thank_you_link_url_settings"
+                                                                          dictionary:@{
+                                                                                       @"add_comment_param_to_url": @1,
+                                                                                       @"add_email_param_to_url": @0,
+                                                                                       @"add_score_param_to_url": @0
+                                                                                       }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://promoter.com?wootric_comment=Very%20Good"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Very Good" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Promoter thank you link text");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreCommentForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                     @"add_comment_param_to_url": @1,
+                                                                                                     @"add_email_param_to_url": @1,
+                                                                                                     @"add_score_param_to_url": @1
+                                                                                                    }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_email=testing@wootric.com&wootric_score=10&wootric_comment=Bueno"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailScoreForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @0,
+                                                                                                                @"add_email_param_to_url": @1,
+                                                                                                                @"add_score_param_to_url": @1
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_email=testing@wootric.com&wootric_score=10"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailCommentForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @1,
+                                                                                                                @"add_email_param_to_url": @1,
+                                                                                                                @"add_score_param_to_url": @0
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_email=testing@wootric.com&wootric_comment=Bueno"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScoreCommentForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @1,
+                                                                                                                @"add_email_param_to_url": @0,
+                                                                                                                @"add_score_param_to_url": @1
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_score=10&wootric_comment=Bueno"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithEmailForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @0,
+                                                                                                                @"add_email_param_to_url": @1,
+                                                                                                                @"add_score_param_to_url": @0
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_email=testing@wootric.com"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithScoreForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @0,
+                                                                                                                @"add_email_param_to_url": @0,
+                                                                                                                @"add_score_param_to_url": @1
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_score=10"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
+- (void)testThankYouLinkWithCommentForAllRespondents {
+  [_settings parseDataFromSurveyServer:[self surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:@{
+                                                                                                                @"add_comment_param_to_url": @1,
+                                                                                                                @"add_email_param_to_url": @0,
+                                                                                                                @"add_score_param_to_url": @0
+                                                                                                                }]];
+  
+  NSURL *thankYouURL = [NSURL URLWithString:@"https://wootric.com?wootric_comment=Bueno"];
+  NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"Bueno" email:@"testing@wootric.com"];
+  XCTAssertEqualObjects(thankYouLinkText, @"Button");
+  XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
+}
+
 - (void)testFollowupPlaceholder {
   NSString *followupPlaceholderDetractor = [_settings followupPlaceholderTextForScore:1];
   XCTAssertEqualObjects(followupPlaceholderDetractor, @"Help us by explaining your score.");
@@ -207,7 +531,7 @@
   NSURL *thankYouURL = [NSURL URLWithString:@"http://thankyou.com"];
   [_settings setThankYouLinkWithText:@"thank you text" URL:thankYouURL];
   NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
-  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 andText:@""];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkText, @"thank you text");
   XCTAssertEqualObjects(thankYouURL, thankYouLinkURL);
 }
@@ -218,7 +542,7 @@
   [_settings setThankYouLinkWithText:@"thank you text" URL:thankYouURL];
   [_settings setDetractorThankYouLinkWithText:@"detractor thank you" URL:detractorThankYouURL];
   NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:1];
-  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 andText:@""];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkText, @"detractor thank you");
   XCTAssertEqualObjects(thankYouLinkURL, detractorThankYouURL);
 }
@@ -229,7 +553,7 @@
   [_settings setThankYouLinkWithText:@"thank you text" URL:thankYouURL];
   [_settings setPassiveThankYouLinkWithText:@"passive thank you" URL:passiveThankYouURL];
   NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:8];
-  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 andText:@""];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkText, @"passive thank you");
   XCTAssertEqualObjects(thankYouLinkURL, passiveThankYouURL);
 }
@@ -240,7 +564,7 @@
   [_settings setThankYouLinkWithText:@"thank you text" URL:thankYouURL];
   [_settings setPromoterThankYouLinkWithText:@"promoter thank you" URL:promoterThankYouURL];
   NSString *thankYouLinkText = [_settings thankYouLinkTextDependingOnScore:10];
-  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 andText:@""];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkText, @"promoter thank you");
   XCTAssertEqualObjects(thankYouLinkURL, promoterThankYouURL);
 }
@@ -268,11 +592,11 @@
   [_settings setDetractorThankYouLinkWithText:@"detractor thank you" URL:detractorThankYouURL];
   [_settings setPassiveThankYouLinkWithText:@"passive thank you" URL:passiveThankYouURL];
   [_settings setPromoterThankYouLinkWithText:@"promoter thank you" URL:promoterThankYouURL];
-  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 andText:@""];
+  NSURL *thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:1 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkURL, detractorThankYouURL);
-  thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 andText:@""];
+  thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:8 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkURL, passiveThankYouURL);
-  thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 andText:@""];
+  thankYouLinkURL = [_settings thankYouLinkURLDependingOnScore:10 text:@"" email:@"testing@wootric.com"];
   XCTAssertEqualObjects(thankYouLinkURL, promoterThankYouURL);
 }
 
@@ -470,6 +794,163 @@
     }
   };
 
+  return settings;
+}
+
+- (NSDictionary *)surveyServerSettingsWithThankYouLinkAllRespondentsWithDictionary:(NSDictionary *)dict {
+  NSDictionary *settings = @{
+                             @"eligible": @1,
+                             @"settings": @{
+                                 @"time_delay": @10,
+                                 @"first_survey": @30,
+                                 @"resurvey_throttle": @180,
+                                 @"decline_resurvey_throttle": @30,
+                                 @"custom_thank_you": @{
+                                   @"thank_you_links": @{
+                                     @"thank_you_link_text": @"Button",
+                                     @"thank_you_link_url": @"https://wootric.com",
+                                     @"thank_you_link_url_settings": dict
+                                   }
+                                 },
+                                 @"survey_type": @"NPS",
+                                 @"localized_texts": @{
+                                     @"nps_question": @"How likely are you to recommend Wootric to a friend or co-worker?",
+                                     @"anchors": @{
+                                         @"likely": @"Extremely likely",
+                                         @"not_likely": @"Not at all likely"
+                                         },
+                                     @"ces_question": @"How easy was it for you to use Wootric?",
+                                     @"ces_anchors": @{
+                                         @"very_difficult": @"Very difficult",
+                                         @"difficult": @"Difficult",
+                                         @"somewhat_difficult": @"Somewhat difficult",
+                                         @"neutral": @"Neutral",
+                                         @"somewhat_easy": @"Somewhat easy",
+                                         @"easy": @"Easy",
+                                         @"very_easy": @"Very easy"
+                                         },
+                                     @"csat_question": @"How satisfied are you with Wootric?",
+                                     @"csat_anchors": @{
+                                         @"very_unsatisfied": @"Very unsatisfied",
+                                         @"unsatisfied": @"Unsatisfied",
+                                         @"neutral": @"Neutral",
+                                         @"satisfied": @"Satisfied",
+                                         @"very_satisfied": @"Very satisfied"
+                                         },
+                                     @"dismiss": @"dismiss",
+                                     @"followup_placeholder": @"Help us by explaining your score.",
+                                     @"followup_question": @"Thank you! Care to tell us why?",
+                                     @"final_thank_you": @"Thank you for your response, and your feedback!",
+                                     @"send": @"send",
+                                     @"edit_score": @"edit",
+                                     @"dismiss": @"dismiss",
+                                     @"social_share": @{
+                                         @"decline": @"No thanks...",
+                                         @"question": @"Would you be willing to share your positive comments?"
+                                         }
+                                     }
+                                 }
+                             };
+  
+  return settings;
+}
+
+- (NSDictionary *)surveyServerSettingsWithThankYouWithKey:(NSString *)key dictionary:(NSDictionary *)dict {
+  NSDictionary *settings = @{
+    @"eligible": @1,
+    @"settings": @{
+      @"account_id": @4321,
+      @"account_token": @"NPS-abcd1234",
+      @"ask_permission_to_share_feedback": @0,
+      @"custom_thank_you": @{
+        @"thank_you_links": @{
+          @"thank_you_link_text_list": @{
+            @"detractor_thank_you_link_text": @"Detractor thank you link text",
+            @"passive_thank_you_link_text": @"Passive thank you link text",
+            @"promoter_thank_you_link_text": @"Promoter thank you link text"
+          },
+          @"thank_you_link_url_list": @{
+            @"detractor_thank_you_link_url": @"https://detractor.com",
+            @"passive_thank_you_link_url": @"https://passive.com",
+            @"promoter_thank_you_link_url": @"https://promoter.com"
+          },
+          @"thank_you_link_url_settings": @{
+            @"add_comment_param_to_url": @0,
+            @"add_email_param_to_url": @0,
+            @"add_score_param_to_url": @0
+          },
+          @"thank_you_link_url_settings_list": @{ key: dict }
+        }
+      },
+      @"decline_resurvey_throttle": @2,
+      @"end_user_email": @"test@wootric.com",
+      @"end_user_id": @1234567,
+      @"first_screen_enabled": @1,
+      @"first_survey": @1,
+      @"localized_texts": @{
+        @"anchors": @{
+          @"likely": @"Extremely likely",
+          @"not_likely": @"Not at all likely"
+        },
+        @"and": @"and",
+        @"ask_permission_to_share_feedback": @"I give permission to contact me about sharing my feedback",
+        @"ces_anchors": @{
+          @"difficult": @"Difficult",
+          @"easy": @"Easy",
+          @"neutral": @"Neutral",
+          @"somewhat_difficult": @"Somewhat difficult",
+          @"somewhat_easy": @"Somewhat easy",
+          @"very_difficult": @"Very difficult",
+          @"very_easy": @"Very easy",
+        },
+        @"ces_question": @"How easy was it for you to Wootric?",
+        @"csat_anchors": @{
+          @"neutral": @"Neutral",
+          @"satisfied": @"Satisfied",
+          @"unsatisfied": @"Unsatisfied",
+          @"very_satisfied": @"Completely satisfied",
+          @"very_unsatisfied": @"Not at all satisfied",
+        },
+        @"csat_question": @"How satisfied are you with Wootric?",
+        @"dir": @"ltr",
+        @"dismiss": @"dismiss",
+        @"edit_score": @"Edit score",
+        @"email": @{
+          @"already_answered": @"You have already answered this survey!",
+        },
+        @"final_thank_you": @"Thank you for your response, and your feedback!",
+        @"followup_placeholder": @"Help us by explaining your score.",
+        @"followup_question": @"Thank you! Care to tell us why?",
+        @"nps_question": @"How likely are you to recommend Wootric to a friend or co-worker?",
+        @"opt_out": @"Confirmed. You've been opted out of future surveys.",
+        @"opt_out_button": @"opt out",
+        @"score_message": @"Please reply with a score between",
+        @"send": @"SEND",
+        @"social_share": @{
+          @"decline": @"No thanks...",
+          @"question": @"Would you be willing to share your positive comments?",
+        },
+        @"unsubscribe": @{
+          @"message": @"You have successfully unsubscribed from receiving this customer feedback survey in the future.",
+          @"title": @"Unsubscribe",
+        },
+      },
+      @"powered_by": @1,
+      @"resurvey_throttle": @2,
+      @"sampling_group": @{
+        @"belongs_to_sampling_group": @0,
+      },
+      @"second_screen_enabled": @1,
+      @"show_opt_out": @0,
+      @"social": @{
+        @"facebook_enabled": @0,
+        @"twitter_enabled": @0,
+      },
+      @"survey_type": @"NPS",
+      @"time_delay": @0
+      }
+    };
+    
   return settings;
 }
 


### PR DESCRIPTION
Pull values from the admin panel and use them in the SDK.

## Changes

- Support `add_comment_param_to_url`,`add_email_param_to_url` and `add_score_param_to_url`
- Update test

## Test

This PR should be tested using the checkboxes present in the 3rd screen of customizing the survey.

![Screen Shot 2019-11-26 at 5 56 02 PM](https://user-images.githubusercontent.com/1431421/69679436-1e5fc680-1076-11ea-964c-1866cfed99ad.png)

Depending on what is selected there, the URL should contain `wootric_email`, `wootric_score` and `wootric_comment`.

Here's a little table to help testing

| Combinations  | Email    | Score    | Comment  |
|---------------|----------|----------|----------|
| Combination 1 | Enabled  | Enabled  | Enabled  |
| Combination 2 | Enabled  | Enabled  | Disabled |
| Combination 3 | Enabled  | Disabled | Enabled  |
| Combination 4 | Enabled  | Disabled | Disabled |
| Combination 5 | Disabled | Enabled  | Enabled  |
| Combination 6 | Disabled | Enabled  | Disabled |
| Combination 7 | Disabled | Disabled | Enabled  |
| Combination 8 | Disabled | Disabled | Disabled |

- [x] Combination 1
- [x] Combination 2
- [x] Combination 3
- [x] Combination 4
- [x] Combination 5
- [x] Combination 6
- [x] Combination 7
- [x] Combination 8

- [x] All
- [x] Detractors
- [x] Passives
- [x] Promoters
