### PR TITLE
Adds basic Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "WootricSDK",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), .tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "WootricSDK", targets: ["WootricSDK"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "WootricSDK",
+            dependencies: [],
+            path: "WootricSDK/WootricSDK"
+        )
+    ]
+)


### PR DESCRIPTION
Adding a package.swift allows for WootricSDK to be built via Accio, a middle ground until SPM supports adding resources. Here's a link to [Accio](https://github.com/JamitLabs/Accio) for more context information.