### PR TITLE
Event queue

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.17.0 (2020-03-26)
+
+### Changes:
+
+- Add support for events (Targeted Sampling)
+
 ## 0.16.0 (2019-12-04)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.16.0"
+	pod "WootricSDK", "~> 0.17.0"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.16.0'
+  s.version  = '0.17.0'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -31,6 +31,12 @@
 		178571982088FCA800CCBE02 /* WTRLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 178571962088FCA700CCBE02 /* WTRLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		178571992088FCA800CCBE02 /* WTRLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 178571972088FCA700CCBE02 /* WTRLogger.m */; };
 		1785719B2088FD1500CCBE02 /* WTRLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1785719A2088FD1500CCBE02 /* WTRLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E0D323B242041FD0034CEBD /* WTREvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0D3239242041FD0034CEBD /* WTREvent.h */; };
+		7E0D323C242041FD0034CEBD /* WTREvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0D323A242041FD0034CEBD /* WTREvent.m */; };
+		7E0D323F24207C960034CEBD /* WTROperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0D323D24207C960034CEBD /* WTROperation.h */; };
+		7E0D324024207C960034CEBD /* WTROperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0D323E24207C960034CEBD /* WTROperation.m */; };
+		7E6BA6C524297B9600D27EE8 /* WTREventListOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E6BA6C324297B9600D27EE8 /* WTREventListOperation.h */; };
+		7E6BA6C624297B9600D27EE8 /* WTREventListOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E6BA6C424297B9600D27EE8 /* WTREventListOperation.m */; };
 		7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */; };
 		7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */; };
 		B2102A2D1BB59ABC0025DABC /* WTRDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = B2102A2B1BB59ABC0025DABC /* WTRDefaults.h */; };
@@ -154,6 +160,12 @@
 		178571962088FCA700CCBE02 /* WTRLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRLogger.h; sourceTree = "<group>"; };
 		178571972088FCA700CCBE02 /* WTRLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WTRLogger.m; sourceTree = "<group>"; };
 		1785719A2088FD1500CCBE02 /* WTRLogLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRLogLevel.h; sourceTree = "<group>"; };
+		7E0D3239242041FD0034CEBD /* WTREvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTREvent.h; sourceTree = "<group>"; };
+		7E0D323A242041FD0034CEBD /* WTREvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTREvent.m; sourceTree = "<group>"; };
+		7E0D323D24207C960034CEBD /* WTROperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTROperation.h; sourceTree = "<group>"; };
+		7E0D323E24207C960034CEBD /* WTROperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTROperation.m; sourceTree = "<group>"; };
+		7E6BA6C324297B9600D27EE8 /* WTREventListOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WTREventListOperation.h; sourceTree = "<group>"; };
+		7E6BA6C424297B9600D27EE8 /* WTREventListOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WTREventListOperation.m; sourceTree = "<group>"; };
 		7E74E3341C8E986F00BCB84F /* NSString+FontAwesome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FontAwesome.h"; sourceTree = "<group>"; };
 		7E74E3351C8E987000BCB84F /* NSString+FontAwesome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FontAwesome.m"; sourceTree = "<group>"; };
 		B2102A2B1BB59ABC0025DABC /* WTRDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTRDefaults.h; sourceTree = "<group>"; };
@@ -431,6 +443,12 @@
 				0FE0F3FC20DC059700499248 /* WTRDefaultNotificationCenter.m */,
 				0F370D5721ACAAF10007C27A /* WTRUtils.h */,
 				0F370D5821ACAAF10007C27A /* WTRUtils.m */,
+				7E0D3239242041FD0034CEBD /* WTREvent.h */,
+				7E0D323A242041FD0034CEBD /* WTREvent.m */,
+				7E0D323D24207C960034CEBD /* WTROperation.h */,
+				7E0D323E24207C960034CEBD /* WTROperation.m */,
+				7E6BA6C324297B9600D27EE8 /* WTREventListOperation.h */,
+				7E6BA6C424297B9600D27EE8 /* WTREventListOperation.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -538,6 +556,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0FA645112289E475008A1C00 /* WTRCustomSocial.h in Headers */,
+				7E6BA6C524297B9600D27EE8 /* WTREventListOperation.h in Headers */,
 				B2C940681BA71A2900482494 /* WTRSliderDot.h in Headers */,
 				B2DC6F2E1B82000900F599B3 /* Wootric.h in Headers */,
 				B2D9FCDF1BF9F18E00479F9F /* SEGWootric.h in Headers */,
@@ -554,6 +573,7 @@
 				B260ECDD1BD7E5B200E29CD5 /* UIView+Constraints.h in Headers */,
 				0FE0F3FD20DC059700499248 /* WTRDefaultNotificationCenter.h in Headers */,
 				B268667E1BD63B7000A4288D /* WTRCircleScoreButton.h in Headers */,
+				7E0D323B242041FD0034CEBD /* WTREvent.h in Headers */,
 				7E74E3361C8E987000BCB84F /* NSString+FontAwesome.h in Headers */,
 				B24550A51B909AC9001AC1FB /* WTRSurveyViewController+Constraints.h in Headers */,
 				B27889791BE0E168001D5696 /* WTRiPADSocialShareView.h in Headers */,
@@ -585,6 +605,7 @@
 				B2DC6F331B820E6B00F599B3 /* WTRApiClient.h in Headers */,
 				B2C940601BA300A000482494 /* WTRSlider.h in Headers */,
 				0F23A96A227A4C000093765A /* WTRUserCustomThankYou.h in Headers */,
+				7E0D323F24207C960034CEBD /* WTROperation.h in Headers */,
 				B278896D1BD914F2001D5696 /* SimpleConstraints.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -694,6 +715,7 @@
 				B2102A341BB59ACE0025DABC /* WTRCustomMessages.m in Sources */,
 				B22976761BB1404D00FC2772 /* WTRCustomThankYou.m in Sources */,
 				B229766E1BB0036100FC2772 /* WTRPropertiesParser.m in Sources */,
+				7E0D324024207C960034CEBD /* WTROperation.m in Sources */,
 				B260ECDE1BD7E5B200E29CD5 /* UIView+Constraints.m in Sources */,
 				B268666F1BD5339800A4288D /* WTRiPADSurveyViewController.m in Sources */,
 				B2C940651BA30AFB00482494 /* UIImage+ImageFromColor.m in Sources */,
@@ -709,12 +731,14 @@
 				B245509E1B909A03001AC1FB /* WTRSurveyViewController.m in Sources */,
 				B24550A61B909AC9001AC1FB /* WTRSurveyViewController+Constraints.m in Sources */,
 				B2C940611BA300A000482494 /* WTRSlider.m in Sources */,
+				7E0D323C242041FD0034CEBD /* WTREvent.m in Sources */,
 				7E74E3371C8E987000BCB84F /* NSString+FontAwesome.m in Sources */,
 				B2D9FCE01BF9F18E00479F9F /* SEGWootric.m in Sources */,
 				178571992088FCA800CCBE02 /* WTRLogger.m in Sources */,
 				B278897E1BE105D6001D5696 /* WTRiPADThankYouButton.m in Sources */,
 				B27889711BDA5520001D5696 /* WTRiPADFeedbackView.m in Sources */,
 				0F370D5A21ACAAF10007C27A /* WTRUtils.m in Sources */,
+				7E6BA6C624297B9600D27EE8 /* WTREventListOperation.m in Sources */,
 				B27889761BDF85FD001D5696 /* UIItems.m in Sources */,
 				B268668B1BD671D200A4288D /* WTRiPADQuestionView.m in Sources */,
 				B24550A21B909A49001AC1FB /* WTRSurveyViewController+Views.m in Sources */,
@@ -888,6 +912,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
+				MARKETING_VERSION = 0.17.0;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -908,6 +933,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
+				MARKETING_VERSION = 0.17.0;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/WootricSDK/WootricSDK/Info.plist
+++ b/WootricSDK/WootricSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.16.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WootricSDK/WootricSDK/WTRApiClient.h
+++ b/WootricSDK/WootricSDK/WTRApiClient.h
@@ -31,12 +31,11 @@
 @property (nonatomic, strong) NSString *clientSecret;
 @property (nonatomic, strong) NSString *clientID;
 @property (nonatomic, strong) NSString *accountToken;
-@property (nonatomic, strong) NSString *apiVersion;
 
 + (instancetype)sharedInstance;
-- (BOOL)checkConfiguration;
+- (void)getRegisteredEventList:(void (^)(NSArray *))completionHandler;
 - (void)authenticate:(void (^)(void))completionHandler;
-- (void)checkEligibility:(void (^)(void))completionHandler;
+- (void)checkEligibility:(void (^)(BOOL))completionHandler;
 - (void)endUserDeclined;
 - (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text;
 

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.m
@@ -49,9 +49,9 @@
       if (thankYouLinks[@"thank_you_link_text"] && thankYouLinks[@"thank_you_link_url"]) {
         _thankYouLinkText = thankYouLinks[@"thank_you_link_text"];
         _thankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url"]];
-        _isEmailInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_email_param_to_url"] integerValue];
-        _isScoreInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_score_param_to_url"] integerValue];
-        _isCommentInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_comment_param_to_url"] integerValue];
+        _isEmailInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_email_param_to_url"] intValue];
+        _isScoreInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_score_param_to_url"] intValue];
+        _isCommentInURL = [thankYouLinks[@"thank_you_link_url_settings"][@"add_comment_param_to_url"] intValue];
       } else {
         NSDictionary *thankYouLinkUrlSettingsList = thankYouLinks[@"thank_you_link_url_settings_list"];
         NSDictionary *detractorThankYouLinkUrlSettings = thankYouLinkUrlSettingsList[@"detractor_thank_you_link_url_settings"];
@@ -60,21 +60,21 @@
         
         _detractorThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"detractor_thank_you_link_text"];
         _detractorThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"detractor_thank_you_link_url"]];
-        _isDetractorEmailInURL = [detractorThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
-        _isDetractorScoreInURL = [detractorThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
-        _isDetractorCommentInURL = [detractorThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
+        _isDetractorEmailInURL = [detractorThankYouLinkUrlSettings[@"add_email_param_to_url"] intValue];
+        _isDetractorScoreInURL = [detractorThankYouLinkUrlSettings[@"add_score_param_to_url"] intValue];
+        _isDetractorCommentInURL = [detractorThankYouLinkUrlSettings[@"add_comment_param_to_url"] intValue];
         
         _passiveThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"passive_thank_you_link_text"];
         _passiveThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"passive_thank_you_link_url"]];
-        _isPassiveEmailInURL = [passiveThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
-        _isPassiveScoreInURL = [passiveThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
-        _isPassiveCommentInURL = [passiveThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
+        _isPassiveEmailInURL = [passiveThankYouLinkUrlSettings[@"add_email_param_to_url"] intValue];
+        _isPassiveScoreInURL = [passiveThankYouLinkUrlSettings[@"add_score_param_to_url"] intValue];
+        _isPassiveCommentInURL = [passiveThankYouLinkUrlSettings[@"add_comment_param_to_url"] intValue];
         
         _promoterThankYouLinkText = thankYouLinks[@"thank_you_link_text_list"][@"promoter_thank_you_link_text"];
         _promoterThankYouLinkURL = [NSURL URLWithString:thankYouLinks[@"thank_you_link_url_list"][@"promoter_thank_you_link_url"]];
-        _isPromoterEmailInURL = [promoterThankYouLinkUrlSettings[@"add_email_param_to_url"] integerValue];
-        _isPromoterScoreInURL = [promoterThankYouLinkUrlSettings[@"add_score_param_to_url"] integerValue];
-        _isPromoterCommentInURL = [promoterThankYouLinkUrlSettings[@"add_comment_param_to_url"] integerValue];
+        _isPromoterEmailInURL = [promoterThankYouLinkUrlSettings[@"add_email_param_to_url"] intValue];
+        _isPromoterScoreInURL = [promoterThankYouLinkUrlSettings[@"add_score_param_to_url"] intValue];
+        _isPromoterCommentInURL = [promoterThankYouLinkUrlSettings[@"add_comment_param_to_url"] intValue];
       }
     }
   }

--- a/WootricSDK/WootricSDK/WTREvent.h
+++ b/WootricSDK/WootricSDK/WTREvent.h
@@ -1,5 +1,5 @@
 //
-//  WTRSurvey.h
+//  WTREvent.h
 //  WootricSDK
 //
 // Copyright (c) 2018 Wootric (https://wootric.com)
@@ -23,19 +23,15 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "WTROperation.h"
 #import "WTRSettings.h"
 
-@interface WTRSurvey : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, strong) WTRSettings *settings;
-@property (nonatomic, strong) NSString *clientSecret;
-@property (nonatomic, strong) NSString *clientID;
-@property (nonatomic, strong) NSString *accountToken;
+@interface WTREvent : WTROperation
 
-+ (instancetype)sharedInstance;
-- (BOOL)checkConfiguration;
-- (void)survey:(void (^)(WTRSettings *))completionHandler;
-- (void)endUserDeclined;
-- (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text;
+- (instancetype)initWithRequest:(NSDictionary *)request eventList:(NSArray *)eventList completion:(void (^)(WTRSettings *settings))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WootricSDK/WootricSDK/WTREvent.m
+++ b/WootricSDK/WootricSDK/WTREvent.m
@@ -1,0 +1,108 @@
+//
+//  WTREvent.m
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTREvent.h"
+#import "WTRApiClient.h"
+#import "WTRLogger.h"
+
+@interface WTREvent ()
+
+@property (nonatomic, copy) void (^completion)(WTRSettings *settings);
+@property (nonatomic, strong) NSDictionary *request;
+@property (nonatomic, strong) NSArray *eventList;
+
+@end
+
+@implementation WTREvent
+
+#pragma mark - Init
+
+- (instancetype)initWithRequest:(NSDictionary *)request eventList:(NSArray *)eventList completion:(void (^)(WTRSettings *settings))completion {
+  self = [super init];
+  if (self) {
+    self.request = request;
+    self.eventList = eventList;
+    self.completion = completion;
+    self.name = @"Wootric-Event";
+  }
+  return self;
+}
+
+#pragma mark - Start
+
+- (void)start {
+  [super start];
+  
+  if ([self isCancelled]) { return; }
+  
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.clientID = [self.request valueForKey:@"clientID"];
+  apiClient.clientSecret = [self.request valueForKey:@"clientSecret"];
+  apiClient.accountToken = [self.request valueForKey:@"accountToken"];
+  apiClient.settings = [self.request valueForKey:@"settings"];
+  
+  if (apiClient.settings.eventName) {
+    if ([self isRegisteredEvent:apiClient.settings.eventName]) {
+      [self checkEligibility:apiClient];
+    } else {
+      [WTRLogger logError:@"Event name not registered"];
+      self.completion(nil);
+      [self finish];
+    }
+  } else {
+    [self checkEligibility:apiClient];
+  }
+}
+
+- (void)checkEligibility:(WTRApiClient *)apiClient {
+  [apiClient checkEligibility:^(BOOL eligible){
+    if (eligible) {
+      [apiClient authenticate:^{
+        self.completion(apiClient.settings);
+        [self finish];
+      }];
+    } else {
+      self.completion(nil);
+      [self finish];
+    }
+  }];
+}
+
+- (BOOL)isRegisteredEvent:(NSString *)eventName {
+  if (((int)[self.eventList indexOfObject:eventName]) == -1) {
+    return NO;
+  } else {
+    return YES;
+  }
+}
+
+#pragma mark - Cancel
+
+- (void)cancel {
+  [super cancel];
+  
+  [self finish];
+}
+
+@end

--- a/WootricSDK/WootricSDK/WTREventListOperation.h
+++ b/WootricSDK/WootricSDK/WTREventListOperation.h
@@ -1,0 +1,19 @@
+//
+//  WTREventListOperation.h
+//  WootricSDK
+//
+//  Created by Diego Serrano on 3/23/20.
+//  Copyright © 2020 Wootric. All rights reserved.
+//
+
+#import "WTROperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WTREventListOperation : WTROperation
+
+- (instancetype)initWithAccountToken:(NSString *)accountToken completion:(void (^)(NSArray *eventList))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WootricSDK/WootricSDK/WTREventListOperation.m
+++ b/WootricSDK/WootricSDK/WTREventListOperation.m
@@ -1,0 +1,48 @@
+//
+//  WTREventListOperation.m
+//  WootricSDK
+//
+//  Created by Diego Serrano on 3/23/20.
+//  Copyright © 2020 Wootric. All rights reserved.
+//
+
+#import "WTREventListOperation.h"
+#import "WTRApiClient.h"
+
+@interface WTREventListOperation ()
+
+@property (nonatomic, copy) void (^completion)(NSArray *eventList);
+@property (nonatomic, strong) NSString *accountToken;
+
+@end
+
+@implementation WTREventListOperation
+
+- (instancetype)initWithAccountToken:(NSString *)accountToken completion:(void (^)(NSArray *eventList))completion {
+  self = [super init];
+  if (self) {
+    self.accountToken = accountToken;
+    self.completion = completion;
+  }
+  return self;
+}
+
+- (void)start {
+  [super start];
+  
+  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  apiClient.accountToken = self.accountToken;
+  
+  [apiClient getRegisteredEventList:^(NSArray *eventList){
+    self.completion([NSArray arrayWithArray:eventList]);
+    [self finish];
+  }];
+}
+
+- (void)cancel {
+  [super cancel];
+  
+  [self finish];
+}
+
+@end

--- a/WootricSDK/WootricSDK/WTRNotificationCenter.h
+++ b/WootricSDK/WootricSDK/WTRNotificationCenter.h
@@ -25,7 +25,7 @@
 #import <Foundation/Foundation.h>
 
 @interface WTRNotificationCenter : NSObject
-- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject;
-- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject;
-- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo;
+- (void)addObserver:(id _Nonnull )observer selector:(SEL _Nonnull )aSelector name:(nullable NSNotificationName)aName object:(nullable id)anObject;
+- (void)postNotificationName:(NSNotificationName _Nonnull )aName object:(nullable id)anObject;
+- (void)postNotificationName:(NSNotificationName _Nonnull )aName object:(nullable id)anObject userInfo:(nullable NSDictionary *)aUserInfo;
 @end

--- a/WootricSDK/WootricSDK/WTROperation.h
+++ b/WootricSDK/WootricSDK/WTROperation.h
@@ -1,5 +1,5 @@
 //
-//  WTRSurvey.h
+//  WTROperation.h
 //  WootricSDK
 //
 // Copyright (c) 2018 Wootric (https://wootric.com)
@@ -23,19 +23,13 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "WTRSettings.h"
 
-@interface WTRSurvey : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, strong) WTRSettings *settings;
-@property (nonatomic, strong) NSString *clientSecret;
-@property (nonatomic, strong) NSString *clientID;
-@property (nonatomic, strong) NSString *accountToken;
+@interface WTROperation : NSOperation
 
-+ (instancetype)sharedInstance;
-- (BOOL)checkConfiguration;
-- (void)survey:(void (^)(WTRSettings *))completionHandler;
-- (void)endUserDeclined;
-- (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text;
+- (void)finish;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WootricSDK/WootricSDK/WTROperation.m
+++ b/WootricSDK/WootricSDK/WTROperation.m
@@ -1,0 +1,103 @@
+//
+//  WTROperation.m
+//  WootricSDK
+//
+// Copyright (c) 2018 Wootric (https://wootric.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "WTROperation.h"
+
+@implementation WTROperation
+
+@synthesize ready = _ready;
+@synthesize executing = _executing;
+@synthesize finished = _finished;
+
+#pragma mark - Init
+
+- (instancetype)init {
+    self = [super init];
+    
+    if (self) {
+        self.ready = YES;
+    }
+    
+    return self;
+}
+
+#pragma mark - State
+
+- (void)setReady:(BOOL)ready {
+    if (_ready != ready) {
+        [self willChangeValueForKey:NSStringFromSelector(@selector(isReady))];
+        _ready = ready;
+        [self didChangeValueForKey:NSStringFromSelector(@selector(isReady))];
+    }
+}
+
+- (BOOL)isReady {
+    return _ready;
+}
+
+- (void)setExecuting:(BOOL)executing {
+    if (_executing != executing) {
+        [self willChangeValueForKey:NSStringFromSelector(@selector(isExecuting))];
+        _executing = executing;
+        [self didChangeValueForKey:NSStringFromSelector(@selector(isExecuting))];
+    }
+}
+
+- (BOOL)isExecuting {
+    return _executing;
+}
+
+- (void)setFinished:(BOOL)finished {
+  if (_finished != finished) {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(isFinished))];
+    _finished = finished;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(isFinished))];
+  }
+}
+
+- (BOOL)isFinished {
+    return _finished;
+}
+
+- (BOOL)isAsynchronous {
+    return YES;
+}
+
+#pragma mark - Control
+
+- (void)start {
+  if (!self.isExecuting) {
+    self.ready = NO;
+    self.executing = YES;
+    self.finished = NO;
+  }
+}
+
+- (void)finish {
+  if (self.executing) {
+    self.executing = NO;
+    self.finished = YES;
+  }
+}
+@end

--- a/WootricSDK/WootricSDK/WTRSettings.h
+++ b/WootricSDK/WootricSDK/WTRSettings.h
@@ -33,6 +33,7 @@
 @property (nonatomic, strong) NSString *customProductName;
 @property (nonatomic, strong) NSString *languageCode;
 @property (nonatomic, strong) NSString *surveyType;
+@property (nonatomic, strong) NSString *eventName;
 @property (nonatomic, assign) NSInteger surveyTypeScale;
 @property (nonatomic, strong) NSDictionary *scale;
 @property (nonatomic, strong) NSString *customAudience;
@@ -128,4 +129,5 @@
 - (void)setCustomDailyResponseCap:(NSNumber *)customDailyResponseCap;
 - (void)setCustomTimeDelay:(NSInteger)customTimeDelay;
 
+-(id)copyWithZone:(NSZone *)zone;
 @end

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -964,4 +964,46 @@
   }
 }
 
+-(id)copyWithZone:(NSZone *)zone{
+  WTRSettings *settingsCopy = [[WTRSettings allocWithZone:zone] init];
+
+  settingsCopy.endUserEmail = self.endUserEmail;
+  settingsCopy.originURL = self.originURL;
+  settingsCopy.productName = self.productName;
+  settingsCopy.customProductName = self.customProductName;
+  settingsCopy.languageCode = self.languageCode;
+  settingsCopy.surveyType = self.surveyType;
+  settingsCopy.eventName = self.eventName;
+  settingsCopy.surveyTypeScale = self.surveyTypeScale;
+  settingsCopy.scale = self.scale;
+  settingsCopy.customAudience = self.customAudience;
+  settingsCopy.customFinalThankYou = self.customFinalThankYou;
+  settingsCopy.customQuestion = self.customQuestion;
+  settingsCopy.externalId = self.externalId;
+  settingsCopy.phoneNumber = self.phoneNumber;
+  settingsCopy.registeredPercentage = self.registeredPercentage;
+  settingsCopy.visitorPercentage = self.visitorPercentage;
+  settingsCopy.resurveyThrottle = self.resurveyThrottle;
+  settingsCopy.declineResurveyThrottle = self.declineResurveyThrottle;
+  settingsCopy.dailyResponseCap = self.dailyResponseCap;
+  settingsCopy.externalCreatedAt = self.externalCreatedAt;
+  settingsCopy.firstSurveyAfter = self.firstSurveyAfter;
+  settingsCopy.customProperties = self.customProperties;
+  settingsCopy.surveyedDefaultDuration = self.surveyedDefaultDuration;
+  settingsCopy.surveyedDefaultDurationDecline = self.surveyedDefaultDurationDecline;
+  settingsCopy.timeDelay = self.timeDelay;
+  settingsCopy.surveyImmediately = self.surveyImmediately;
+  settingsCopy.forceSurvey = self.forceSurvey;
+  settingsCopy.showOptOut = self.showOptOut;
+  settingsCopy.setDefaultAfterSurvey = self.setDefaultAfterSurvey;
+  settingsCopy.skipFeedbackScreen = self.skipFeedbackScreen;
+  settingsCopy.skipFeedbackScreenForPromoter = self.skipFeedbackScreenForPromoter;
+  settingsCopy.passScoreAndTextToURL = self.passScoreAndTextToURL;
+  settingsCopy.sendButtonBackgroundColor = self.sendButtonBackgroundColor;
+  settingsCopy.sliderColor = self.sliderColor;
+  settingsCopy.socialSharingColor = self.socialSharingColor;
+  
+  return settingsCopy;
+}
+
 @end

--- a/WootricSDK/WootricSDK/Wootric.h
+++ b/WootricSDK/WootricSDK/Wootric.h
@@ -48,6 +48,12 @@
 */
 + (void)showSurveyInViewController:(UIViewController *)viewController;
 /**
+ @discussion It shows survey if end user is eligible.
+ @param viewController View controller in which you would like to display the survey.
+ @param eventName Event Name.
+*/
++ (void)showSurveyInViewController:(UIViewController *)viewController event:(NSString *)eventName;
+/**
  @discussion It sets end user's account creation date to provided value (UNIX Timestamp truncated to seconds).
  @param externalCreatedAt UNIX Timestamp truncated to seconds.
 */
@@ -109,6 +115,11 @@
  @param customProperties NSDictionary containing custom properties.
 */
 + (void)setEndUserProperties:(NSDictionary *)customProperties;
+/**
+ @discussion It sets the Event Name
+ @param eventName NSString with the event name.
+*/
++ (void)setEventName:(NSString *)eventName;
 /**
  @discussion Returns an NSDictionary of the end user properties.
  @return NSDictionary of endUserProperties.

--- a/WootricSDK/WootricSDK/Wootric.m
+++ b/WootricSDK/WootricSDK/Wootric.m
@@ -27,7 +27,6 @@
 #import "WTRSurveyViewController.h"
 #import "WTRDefaultNotificationCenter.h"
 #import "WTRiPADSurveyViewController.h"
-#import "WTRApiClient.h"
 #import "WTRLogger.h"
 #import "WTRSurveyDelegate.h"
 
@@ -38,134 +37,139 @@ static id<WTRSurveyDelegate> _delegate = nil;
 @implementation Wootric
 
 + (void)configureWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret accountToken:(NSString *)accountToken {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.clientID = clientID;
-  apiClient.clientSecret = clientSecret;
-  apiClient.accountToken = accountToken;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.clientID = clientID;
+  surveyClient.clientSecret = clientSecret;
+  surveyClient.accountToken = accountToken;
 }
 
 + (void)configureWithClientID:(NSString *)clientID accountToken:(NSString *)accountToken {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.clientID = clientID;
-  apiClient.accountToken = accountToken;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.clientID = clientID;
+  surveyClient.accountToken = accountToken;
 }
 
 + (void)setEndUserEmail:(NSString *)endUserEmail {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.endUserEmail = endUserEmail;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.endUserEmail = endUserEmail;
 }
 
 + (void)setEndUserCreatedAt:(NSNumber *)externalCreatedAt {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.externalCreatedAt = externalCreatedAt;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.externalCreatedAt = externalCreatedAt;
 }
 
 + (void)setEndUserExternalId:(NSString *)externalId {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.externalId = externalId;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.externalId = externalId;
 }
 
 + (void)setEndUserPhoneNumber:(NSString *)phoneNumber {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.phoneNumber = phoneNumber;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.phoneNumber = phoneNumber;
 }
 
 + (void)setCustomAudience:(NSString *)audience {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customAudience = audience;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.customAudience = audience;
 }
 
 + (void)setCustomLanguage:(NSString *)languageCode {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.languageCode = languageCode;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.languageCode = languageCode;
 }
 
 + (void)setCustomProductName:(NSString *)productName {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customProductName = productName;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.customProductName = productName;
 }
 
 + (void)setCustomFinalThankYou:(NSString *)finalThankYou {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customFinalThankYou = finalThankYou;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.customFinalThankYou = finalThankYou;
 }
 
 + (void)setCustomQuestion:(NSString *)question {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customQuestion = question;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.customQuestion = question;
 }
 
 + (void)setSurveyedDefault:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.setDefaultAfterSurvey = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.setDefaultAfterSurvey = flag;
 }
 
 + (void)forceSurvey:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.forceSurvey = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.forceSurvey = flag;
 }
 
 + (void)setSurveyTypeScale:(NSInteger)surveyTypeScale {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.surveyTypeScale = surveyTypeScale;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.surveyTypeScale = surveyTypeScale;
 }
 
 + (void)showOptOut:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.showOptOut = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.showOptOut = flag;
 }
 
 + (void)surveyImmediately:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.surveyImmediately = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.surveyImmediately = flag;
 }
 
 + (void)setEndUserProperties:(NSDictionary *)customProperties {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.customProperties = [NSMutableDictionary dictionaryWithDictionary:customProperties];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.customProperties = [NSMutableDictionary dictionaryWithDictionary:customProperties];
+}
+
++ (void)setEventName:(NSString *)eventName {
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.eventName = eventName;
 }
 
 + (NSDictionary *)endUserProperties {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  return apiClient.settings.customProperties;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  return surveyClient.settings.customProperties;
 }
 
 + (void)setProductNameForEndUser:(NSString *)productName {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.productName = productName;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.productName = productName;
 }
 
 + (void)setFirstSurveyAfter:(NSNumber *)firstSurveyAfter {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.firstSurveyAfter = firstSurveyAfter;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.firstSurveyAfter = firstSurveyAfter;
 }
 
 + (void)skipFeedbackScreenForPromoter:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.skipFeedbackScreenForPromoter = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.skipFeedbackScreenForPromoter = flag;
 }
 
 + (void)skipFeedbackScreen:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.skipFeedbackScreen = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.skipFeedbackScreen = flag;
 }
 
 + (void) passScoreAndTextToURL:(BOOL)flag {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  apiClient.settings.passScoreAndTextToURL = flag;
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  surveyClient.settings.passScoreAndTextToURL = flag;
 }
 
 + (void)passEmailInURL:(BOOL)emailInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   if (emailInURL) {
-    [apiClient.settings setEmailInURL:1];
+    [surveyClient.settings setEmailInURL:1];
   } else {
-    [apiClient.settings setEmailInURL:0];
+    [surveyClient.settings setEmailInURL:0];
   }
 }
 
 + (void)passPromoterEmailInURL:(BOOL)promoterEmailInURL passiveEmailInURL:(BOOL)passiveEmailInURL detractorEmailInURL:(BOOL)detractorEmailInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   int promoter = -1;
   int passive = -1;
   int detractor = -1;
@@ -185,20 +189,20 @@ static id<WTRSurveyDelegate> _delegate = nil;
     detractor = 0;
   }
   
-  [apiClient.settings setPromoterEmailInURL:promoter passiveEmailInURL:passive detractorEmailInURL:detractor];
+  [surveyClient.settings setPromoterEmailInURL:promoter passiveEmailInURL:passive detractorEmailInURL:detractor];
 }
 
 + (void)passScoreInURL:(BOOL)scoreInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   if (scoreInURL) {
-    [apiClient.settings setScoreInURL:1];
+    [surveyClient.settings setScoreInURL:1];
   } else {
-    [apiClient.settings setScoreInURL:0];
+    [surveyClient.settings setScoreInURL:0];
   }
 }
 
 + (void)passPromoterScoreInURL:(BOOL)promoterScoreInURL passiveScoreInURL:(BOOL)passiveScoreInURL detractorScoreInURL:(BOOL)detractorScoreInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   int promoter = -1;
   int passive = -1;
   int detractor = -1;
@@ -218,20 +222,20 @@ static id<WTRSurveyDelegate> _delegate = nil;
     detractor = 0;
   }
   
-  [apiClient.settings setPromoterScoreInURL:promoter passiveScoreInURL:passive detractorScoreInURL:detractor];
+  [surveyClient.settings setPromoterScoreInURL:promoter passiveScoreInURL:passive detractorScoreInURL:detractor];
 }
 
 + (void)passCommentInURL:(BOOL)commentInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   if (commentInURL) {
-    [apiClient.settings setCommentInURL:1];
+    [surveyClient.settings setCommentInURL:1];
   } else {
-    [apiClient.settings setCommentInURL:0];
+    [surveyClient.settings setCommentInURL:0];
   }
 }
 
 + (void)passPromoterCommentInURL:(BOOL)promoterCommentInURL passiveCommentInURL:(BOOL)passiveCommentInURL detractorCommentInURL:(BOOL)detractorCommentInURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
   int promoter = -1;
   int passive = -1;
   int detractor = -1;
@@ -251,21 +255,24 @@ static id<WTRSurveyDelegate> _delegate = nil;
     detractor = 0;
   }
   
-  [apiClient.settings setPromoterCommentInURL:promoter passiveCommentInURL:passive detractorCommentInURL:detractor];
+  [surveyClient.settings setPromoterCommentInURL:promoter passiveCommentInURL:passive detractorCommentInURL:detractor];
+}
+
++ (void)showSurveyInViewController:(UIViewController *)viewController event:(NSString *)eventName {
+  [self setEventName:eventName];
+  [self showSurveyInViewController:viewController];
 }
 
 + (void)showSurveyInViewController:(UIViewController *)viewController {
-    
-  if ([[WTRApiClient sharedInstance] checkConfiguration]) {
-    WTRSurvey *surveyClient = [[WTRSurvey alloc] init];
-    [surveyClient survey:^{
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  if ([surveyClient checkConfiguration]) {
+    [surveyClient survey:^(WTRSettings *settings){
       [WTRLogger log:@"presenting survey view"];
-      WTRApiClient *apiClient = [WTRApiClient sharedInstance];
       
       dispatch_async(dispatch_get_main_queue(), ^{
         [self performSelector:@selector(presentSurveyInViewController:)
-                   withObject:viewController
-                   afterDelay:apiClient.settings.timeDelay];
+                   withObject:@[viewController, settings]
+                   afterDelay:settings.timeDelay];
       });
     }];
   } else {
@@ -273,15 +280,16 @@ static id<WTRSurveyDelegate> _delegate = nil;
   }
 }
 
-+ (void)presentSurveyInViewController:(UIViewController *)viewController {
-  WTRSettings *surveySettings = [WTRApiClient sharedInstance].settings;
-  
++ (void)presentSurveyInViewController:(NSArray *)objects {
+  UIViewController *viewController = objects[0];
+  WTRSettings *settings = objects[1];
+
   if (IPAD) {
-    WTRiPADSurveyViewController *surveyViewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:surveySettings
+    WTRiPADSurveyViewController *surveyViewController = [[WTRiPADSurveyViewController alloc] initWithSurveySettings:settings
                                                                                                  notificationCenter:[[WTRDefaultNotificationCenter alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]]];
     [viewController presentViewController:surveyViewController animated:YES completion:nil];
   } else {
-    WTRSurveyViewController *surveyViewController = [[WTRSurveyViewController alloc] initWithSurveySettings:surveySettings
+    WTRSurveyViewController *surveyViewController = [[WTRSurveyViewController alloc] initWithSurveySettings:settings
                                                                                          notificationCenter:[[WTRDefaultNotificationCenter alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]]];
     [viewController presentViewController:surveyViewController animated:YES completion:nil];
   }
@@ -290,13 +298,13 @@ static id<WTRSurveyDelegate> _delegate = nil;
 #pragma mark - Social Share
 
 + (void)setTwitterHandler:(NSString *)twitterHandler {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setTwitterHandler:twitterHandler];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setTwitterHandler:twitterHandler];
 }
 
 + (void)setFacebookPage:(NSURL *)facebookPage {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setFacebookPage:facebookPage];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setFacebookPage:facebookPage];
 }
 
 #pragma mark - Custom Thanks
@@ -318,92 +326,92 @@ static id<WTRSurveyDelegate> _delegate = nil;
 }
 
 + (void)setThankYouMain:(NSString *)thankYouMain {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setThankYouMain:thankYouMain];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setThankYouMain:thankYouMain];
 }
 
 + (void)setDetractorThankYouMain:(NSString *)detractorThankYouMain {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setDetractorThankYouMain:detractorThankYouMain];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setDetractorThankYouMain:detractorThankYouMain];
 }
 
 + (void)setPassiveThankYouMain:(NSString *)passiveThankYouMain {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPassiveThankYouMain:passiveThankYouMain];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setPassiveThankYouMain:passiveThankYouMain];
 }
 
 + (void)setPromoterThankYouMain:(NSString *)promoterThankYouMain {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPromoterThankYouMain:promoterThankYouMain];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setPromoterThankYouMain:promoterThankYouMain];
 }
 
 + (void)setThankYouLinkWithText:(NSString *)thankYouLinkText URL:(NSURL *)thankYouLinkURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setThankYouLinkWithText:thankYouLinkText URL:thankYouLinkURL];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setThankYouLinkWithText:thankYouLinkText URL:thankYouLinkURL];
 }
 
 + (void)setDetractorThankYouLinkWithText:(NSString *)detractorThankYouLinkText URL:(NSURL *)detractorThankYouLinkURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setDetractorThankYouLinkWithText:detractorThankYouLinkText URL:detractorThankYouLinkURL];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setDetractorThankYouLinkWithText:detractorThankYouLinkText URL:detractorThankYouLinkURL];
 }
 
 + (void)setPassiveThankYouLinkWithText:(NSString *)passiveThankYouLinkText URL:(NSURL *)passiveThankYouLinkURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPassiveThankYouLinkWithText:passiveThankYouLinkText URL:passiveThankYouLinkURL];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setPassiveThankYouLinkWithText:passiveThankYouLinkText URL:passiveThankYouLinkURL];
 }
 
 + (void)setPromoterThankYouLinkWithText:(NSString *)promoterThankYouLinkText URL:(NSURL *)promoterThankYouLinkURL {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setPromoterThankYouLinkWithText:promoterThankYouLinkText URL:promoterThankYouLinkURL];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setPromoterThankYouLinkWithText:promoterThankYouLinkText URL:promoterThankYouLinkURL];
 }
 
 #pragma mark - Application Set Custom Messages
 
 + (void)setCustomFollowupPlaceholderForPromoter:(NSString *)promoterPlaceholder passive:(NSString *)passivePlaceholder detractor:(NSString *)detractorPlaceholder {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setCustomFollowupPlaceholderForPromoter:promoterPlaceholder passive:passivePlaceholder detractor:detractorPlaceholder];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setCustomFollowupPlaceholderForPromoter:promoterPlaceholder passive:passivePlaceholder detractor:detractorPlaceholder];
 }
 
 + (void)setCustomFollowupQuestionForPromoter:(NSString *)promoterQuestion passive:(NSString *)passiveQuestion detractor:(NSString *)detractorQuestion {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setCustomFollowupQuestionForPromoter:promoterQuestion passive:passiveQuestion detractor:detractorQuestion];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setCustomFollowupQuestionForPromoter:promoterQuestion passive:passiveQuestion detractor:detractorQuestion];
 }
 
 #pragma mark - Custom Values For Eligibility
 
 + (void)setCustomValueForResurveyThrottle:(NSNumber *)resurveyThrottle visitorPercentage:(NSNumber *)visitorPercentage registeredPercentage:(NSNumber *)registeredPercentage dailyResponseCap:(NSNumber *)dailyResponseCap {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setCustomResurveyThrottle:resurveyThrottle];
-  [apiClient.settings setCustomVisitorPercentage:visitorPercentage];
-  [apiClient.settings setCustomRegisteredPercentage:registeredPercentage];
-  [apiClient.settings setCustomDailyResponseCap:dailyResponseCap];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setCustomResurveyThrottle:resurveyThrottle];
+  [surveyClient.settings setCustomVisitorPercentage:visitorPercentage];
+  [surveyClient.settings setCustomRegisteredPercentage:registeredPercentage];
+  [surveyClient.settings setCustomDailyResponseCap:dailyResponseCap];
 }
 
 + (void)setCustomTimeDelay:(NSInteger)customTimeDelay {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setCustomTimeDelay:customTimeDelay];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setCustomTimeDelay:customTimeDelay];
 }
 
 #pragma mark - Color Customization
 
 + (void)setSendButtonBackgroundColor:(UIColor *)color {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setSendButtonBackgroundColor:color];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setSendButtonBackgroundColor:color];
 }
 
 + (void)setSliderColor:(UIColor *)color {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setSliderColor:color];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setSliderColor:color];
 }
 
 + (void)setSocialSharingColor:(UIColor *)color {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setSocialSharingColor:color];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setSocialSharingColor:color];
 }
 
 + (void)setThankYouButtonBackgroundColor:(UIColor *)color {
-  WTRApiClient *apiClient = [WTRApiClient sharedInstance];
-  [apiClient.settings setThankYouButtonBackgroundColor:color];
+  WTRSurvey *surveyClient = [WTRSurvey sharedInstance];
+  [surveyClient.settings setThankYouButtonBackgroundColor:color];
 }
 
 #pragma mark - WTRLogger setters

--- a/WootricSDK/WootricSDKTests/SEGWootricTests.m
+++ b/WootricSDK/WootricSDKTests/SEGWootricTests.m
@@ -23,12 +23,12 @@
 // THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
-#import "WTRApiClient.h"
+#import "WTRSurvey.h"
 #import "SEGWootric.h"
 
 @interface SEGWootricTests : XCTestCase
 
-@property (nonatomic, strong) WTRApiClient *apiClient;
+@property (nonatomic, strong) WTRSurvey *surveyClient;
 @property (nonatomic, strong) SEGWootric *segWootric;
 @property (nonatomic, strong) UIColor *color;
 
@@ -38,7 +38,7 @@
 
 - (void)setUp {
   [super setUp];
-  _apiClient = [WTRApiClient sharedInstance];
+  _surveyClient = [WTRSurvey sharedInstance];
   _segWootric = [[SEGWootric alloc] init];
   _color = [UIColor colorWithRed:0.1f green:0.2f blue:0.3f alpha:1.0f];
 }
@@ -54,229 +54,229 @@
   static NSString *accountToken = @"NP-Token";
   [_segWootric configureWithClientID:clientId clientSecret:clientSecret accountToken:accountToken];
   
-  XCTAssertEqualObjects(_apiClient.clientID, clientId, @"clientID should be equal to testClientID");
-  XCTAssertEqualObjects(_apiClient.clientSecret, clientSecret, @"clientSecret should be equal to testClientSecret");
-  XCTAssertEqualObjects(_apiClient.accountToken, accountToken, @"accountToken should be equal to NP-Token");
+  XCTAssertEqualObjects(_surveyClient.clientID, clientId, @"clientID should be equal to testClientID");
+  XCTAssertEqualObjects(_surveyClient.clientSecret, clientSecret, @"clientSecret should be equal to testClientSecret");
+  XCTAssertEqualObjects(_surveyClient.accountToken, accountToken, @"accountToken should be equal to NP-Token");
   
-  _apiClient.clientID = nil;
-  _apiClient.clientSecret = nil;
-  _apiClient.accountToken = nil;
+  _surveyClient.clientID = nil;
+  _surveyClient.clientSecret = nil;
+  _surveyClient.accountToken = nil;
 }
 
 - (void)testSetEndUserCreatedAt {
   NSNumber *endUserCreatedAt = @123;
   [_segWootric setEndUserCreatedAt:endUserCreatedAt];
   
-  XCTAssertEqualObjects(_apiClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
+  XCTAssertEqualObjects(_surveyClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
   
-  _apiClient.settings.externalCreatedAt = nil;
+  _surveyClient.settings.externalCreatedAt = nil;
 }
 
 - (void)testSetEndUserEmail {
   static NSString *endUserEmail = @"test@example.com";
   [_segWootric setEndUserEmail:endUserEmail];
   
-  XCTAssertEqualObjects(_apiClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
+  XCTAssertEqualObjects(_surveyClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
   
-  _apiClient.settings.endUserEmail = nil;
+  _surveyClient.settings.endUserEmail = nil;
 }
 
 - (void)testSetProductNameForEndUser {
   static NSString *productName = @"Example";
   [_segWootric setProductNameForEndUser:@"Example"];
   
-  XCTAssertEqualObjects(_apiClient.settings.productName, productName, @"productName should be equal to Example");
+  XCTAssertEqualObjects(_surveyClient.settings.productName, productName, @"productName should be equal to Example");
   
-  _apiClient.settings.productName = nil;
+  _surveyClient.settings.productName = nil;
 }
 
 - (void)testSetCustomLanguage {
   static NSString *language = @"Epañol";
   [_segWootric setCustomLanguage:language];
   
-  XCTAssertEqualObjects(_apiClient.settings.languageCode, language, @"languageCode should be equal to Español");
+  XCTAssertEqualObjects(_surveyClient.settings.languageCode, language, @"languageCode should be equal to Español");
   
-  _apiClient.settings.languageCode = nil;
+  _surveyClient.settings.languageCode = nil;
 }
 
 - (void)testSetCustomAudience {
   static NSString *audience = @"Custom audience";
   [_segWootric setCustomAudience:audience];
   
-  XCTAssertEqualObjects(_apiClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
+  XCTAssertEqualObjects(_surveyClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
   
-  _apiClient.settings.customAudience = nil;
+  _surveyClient.settings.customAudience = nil;
 }
 
 - (void)testSetCustomProductName {
   static NSString *customProductName = @"Custom product";
   [_segWootric setCustomProductName:customProductName];
   
-  XCTAssertEqualObjects(_apiClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
+  XCTAssertEqualObjects(_surveyClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
   
-  _apiClient.settings.customProductName = nil;
+  _surveyClient.settings.customProductName = nil;
 }
 
 - (void)testSetCustomFinalThankYou {
   static NSString *customFinalThankYou = @"CustomFinalThankYou";
   [_segWootric setCustomFinalThankYou:customFinalThankYou];
   
-  XCTAssertEqualObjects(_apiClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
+  XCTAssertEqualObjects(_surveyClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
   
-  _apiClient.settings.customFinalThankYou = nil;
+  _surveyClient.settings.customFinalThankYou = nil;
 }
 
 - (void)testSetCustomQuestion {
   static NSString *customQuestion = @"Would you recommend this to a friend?";
   [_segWootric setCustomQuestion:customQuestion];
   
-  XCTAssertEqualObjects(_apiClient.settings.customQuestion, customQuestion, @"customQuestion should be equal to Would you recommend this to a friend?");
+  XCTAssertEqualObjects(_surveyClient.settings.customQuestion, customQuestion, @"customQuestion should be equal to Would you recommend this to a friend?");
   
-  _apiClient.settings.customQuestion = nil;
+  _surveyClient.settings.customQuestion = nil;
 }
 
 - (void)testSetEndUserProperties {
   NSDictionary *endUserProperties = @{@"email": @"test@example.com"};
   [_segWootric setEndUserProperties:endUserProperties];
 
-  XCTAssertEqualObjects(_apiClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
+  XCTAssertEqualObjects(_surveyClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
   
-  XCTAssertEqualObjects([_apiClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
+  XCTAssertEqualObjects([_surveyClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
   
-  _apiClient.settings.customProperties = nil;
+  _surveyClient.settings.customProperties = nil;
   
 }
 
 - (void)testSetFirstSurveyAfter {
-  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
+  XCTAssertEqualObjects(_surveyClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
   
   [_segWootric setFirstSurveyAfter:@15];
   
-  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
+  XCTAssertEqualObjects(_surveyClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
   
-  _apiClient.settings.firstSurveyAfter = nil;
+  _surveyClient.settings.firstSurveyAfter = nil;
   
 }
 
 - (void)testSetSurveyedDefault {
-  XCTAssertTrue(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
+  XCTAssertTrue(_surveyClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
   
   [_segWootric setSurveyedDefault:NO];
 
-  XCTAssertFalse(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
+  XCTAssertFalse(_surveyClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
   
-  _apiClient.settings.setDefaultAfterSurvey = YES;
+  _surveyClient.settings.setDefaultAfterSurvey = YES;
 }
 
 - (void)testSurveyImmediately {
   [_segWootric surveyImmediately:YES];
   
-  XCTAssertTrue(_apiClient.settings.surveyImmediately, @"surveyImmediately should be true");
+  XCTAssertTrue(_surveyClient.settings.surveyImmediately, @"surveyImmediately should be true");
   
   [_segWootric surveyImmediately:NO];
   
-  XCTAssertFalse(_apiClient.settings.surveyImmediately, @"surveyImmediately should be false");
+  XCTAssertFalse(_surveyClient.settings.surveyImmediately, @"surveyImmediately should be false");
 }
 
 - (void)testForceSurvey {
   [_segWootric forceSurvey:YES];
   
-  XCTAssertTrue(_apiClient.settings.forceSurvey, @"forceSurvey should be true");
+  XCTAssertTrue(_surveyClient.settings.forceSurvey, @"forceSurvey should be true");
   
-  _apiClient.settings.forceSurvey = NO;
+  _surveyClient.settings.forceSurvey = NO;
 }
 
 - (void)testSkipFeedbackScreenForPromoter {
   [_segWootric skipFeedbackScreenForPromoter:NO];
-  XCTAssertFalse(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be false");
+  XCTAssertFalse(_surveyClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be false");
   [_segWootric skipFeedbackScreenForPromoter:YES];
-  XCTAssertTrue(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be true");
-  _apiClient.settings.skipFeedbackScreenForPromoter = NO;
+  XCTAssertTrue(_surveyClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be true");
+  _surveyClient.settings.skipFeedbackScreenForPromoter = NO;
 }
 
 - (void)testSkipFeedbackScreen {
   [_segWootric skipFeedbackScreen:NO];
-  XCTAssertFalse(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
+  XCTAssertFalse(_surveyClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
   [_segWootric skipFeedbackScreen:YES];
-  XCTAssertTrue(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
-  _apiClient.settings.skipFeedbackScreen = NO;
+  XCTAssertTrue(_surveyClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
+  _surveyClient.settings.skipFeedbackScreen = NO;
 }
 
 - (void)testPassScoreAndTextToURL {
   [_segWootric passScoreAndTextToURL:NO];
   
-  XCTAssertFalse(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
+  XCTAssertFalse(_surveyClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
   
   [_segWootric passScoreAndTextToURL:YES];
   
-  XCTAssertTrue(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
+  XCTAssertTrue(_surveyClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
   
-  _apiClient.settings.passScoreAndTextToURL = NO;
+  _surveyClient.settings.passScoreAndTextToURL = NO;
 }
 
 - (void)testSetFacebookPage {
   NSURL *url = [NSURL URLWithString:@"facebook.com/test"];
   [_segWootric setFacebookPage:url];
   
-  XCTAssertEqualObjects(_apiClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
+  XCTAssertEqualObjects(_surveyClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
   
-  _apiClient.settings.facebookPage = nil;
+  _surveyClient.settings.facebookPage = nil;
 }
 
 - (void)testSetTwitterHandler {
   static NSString *twitterHandler = @"twitter";
   [_segWootric setTwitterHandler:twitterHandler];
   
-  XCTAssertEqualObjects(_apiClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
+  XCTAssertEqualObjects(_surveyClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
   
-  _apiClient.settings.twitterHandler = nil;
+  _surveyClient.settings.twitterHandler = nil;
   
 }
 
 - (void)testSetSendButtonBackgroundColor {
   [_segWootric setSendButtonBackgroundColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
   
-  _apiClient.settings.sendButtonBackgroundColor = nil;
+  _surveyClient.settings.sendButtonBackgroundColor = nil;
 }
 
 - (void)testSetSliderColor {
   [_segWootric setSliderColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.sliderColor, _color, @"sliderColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.sliderColor, _color, @"sliderColor should equal to color");
   
-  _apiClient.settings.sliderColor = nil;
+  _surveyClient.settings.sliderColor = nil;
 }
 
 - (void)testSetThankYouButtonBackgroundColor {
   
   [_segWootric setThankYouButtonBackgroundColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
   
-  _apiClient.settings.thankYouButtonBackgroundColor = nil;
+  _surveyClient.settings.thankYouButtonBackgroundColor = nil;
 }
 
 - (void)testSetSocialSharingColor {
   
   [_segWootric setSocialSharingColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
   
-  _apiClient.settings.socialSharingColor = nil;
+  _surveyClient.settings.socialSharingColor = nil;
 }
 
 - (void)testShowOptOutDefaultNo {
-  XCTAssertFalse(_apiClient.settings.showOptOut, @"showOptOut default value should be NO");
+  XCTAssertFalse(_surveyClient.settings.showOptOut, @"showOptOut default value should be NO");
 }
 
 - (void)testSetShowOptOut {
   [_segWootric showOptOut:YES];
 
-  XCTAssertTrue(_apiClient.settings.showOptOut, @"showOptOut default value should be YES");
+  XCTAssertTrue(_surveyClient.settings.showOptOut, @"showOptOut default value should be YES");
 
-  _apiClient.settings.showOptOut = NO;
+  _surveyClient.settings.showOptOut = NO;
 }
 
 @end

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -24,6 +24,14 @@
 
 #import <XCTest/XCTest.h>
 #import "WTRApiClient.h"
+#import "WTRDefaults.h"
+
+static NSString *const WTRSamplingRule = @"Wootric Sampling Rule";
+static NSString *const WTRRegisterEventsEndpoint = @"/registered_events.json";
+static NSString *const WTREligibleEndpoint = @"/eligible.json";
+static NSString *const WTRSurveyServerURL = @"https://survey.wootric.com";
+static NSString *const WTRBaseAPIURL = @"https://api.wootric.com";
+static NSString *const WTRAPIVersion = @"api/v1";
 
 @interface WTRApiClientTests : XCTestCase
 
@@ -31,11 +39,8 @@
 
 @end
 
-
 @interface WTRApiClient (Tests)
 
-@property (nonatomic, strong) NSString *baseAPIURL;
-@property (nonatomic, strong) NSString *surveyServerURL;
 @property (nonatomic, strong) NSString *accessToken;
 @property (nonatomic, strong) NSURLSession *wootricSession;
 @property (nonatomic) NSInteger userID;
@@ -57,6 +62,7 @@
 - (NSString *)addVersionsToURLString:(NSString *)baseURLString;
 - (NSString *)addPropertiesToURLString:(NSString *)baseURLString;
 - (NSString *)addEmailToURLString:(NSString *)baseURLString;
+- (BOOL)needsSurvey;
 
 @end
 
@@ -66,6 +72,7 @@
   [super setUp];
   
   _apiClient = [WTRApiClient sharedInstance];
+  _apiClient.settings.setDefaultAfterSurvey = YES;
 }
 
 - (void)tearDown {
@@ -80,68 +87,21 @@
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setBool:NO forKey:@"surveyed"];
   [defaults setDouble:0 forKey:@"lastSeenAt"];
+  [defaults setObject:nil forKey:@"resurvey_days"];
 }
 
 -(void)testInstance {
   XCTAssertNotNil(_apiClient, "WTRApiClient instance should not have been nil.");
   
-  XCTAssertEqualObjects(_apiClient.baseAPIURL, @"https://api.wootric.com", @"baseAPIURL should have been equal to https://api.wootric.com");
-  
-  XCTAssertEqualObjects(_apiClient.surveyServerURL, @"https://survey.wootric.com/eligible.json", @"surveyServerURL should have been equal to https://survey.wootric.com/eligible.json");
-  
   XCTAssertNotNil(_apiClient.wootricSession, "wootricSession should not have been nil.");
   
   XCTAssertNotNil(_apiClient.settings, "settings should not have been nil.");
   
-  XCTAssertEqualObjects(_apiClient.apiVersion, @"api/v1", @"apiVersion should have been equal to api/v1");
-  
   XCTAssertEqual(_apiClient.priority, 0, @"priority should have been equal to 0");
 }
 
-- (void)testCheckConfiguration {
-  _apiClient.clientID = @"";
-  _apiClient.clientSecret = @"";
-  _apiClient.accountToken = @"";
-  
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"clientIDtestString";
-  _apiClient.clientSecret = @"clientSecretTestString";
-  _apiClient.accountToken = @"";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"";
-  _apiClient.clientSecret = @"clientSecretTestString";
-  _apiClient.accountToken = @"";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"";
-  _apiClient.clientSecret = @"";
-  _apiClient.accountToken = @"NPS-token";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"clientIDtestString";
-  _apiClient.clientSecret = @"clientSecretTestString";
-  _apiClient.accountToken = @"";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"";
-  _apiClient.clientSecret = @"clientSecretTestString";
-  _apiClient.accountToken = @"NPS-token";
-  XCTAssertFalse([_apiClient checkConfiguration]);
-  
-  _apiClient.clientID = @"clientIDtestString";
-  _apiClient.clientSecret = @"";
-  _apiClient.accountToken = @"NPS-token";
-  XCTAssertTrue([_apiClient checkConfiguration]);
 
-  _apiClient.clientID = @"clientIDtestString";
-  _apiClient.clientSecret = @"clientSecretTestString";
-  _apiClient.accountToken = @"NPS-token";
-  XCTAssertTrue([_apiClient checkConfiguration]);
-}
-
-- (void) testAddSurveyServerCustomSettingsToURLString {
+- (void)testAddSurveyServerCustomSettingsToURLString {
   NSString *baseURLString = @"https://survey.wootric.com/eligible.json?account_token=NPS-token&email=a@test.com";
   
   XCTAssertEqualObjects([_apiClient addSurveyServerCustomSettingsToURLString:baseURLString], @"https://survey.wootric.com/eligible.json?account_token=NPS-token&email=a@test.com&end_user_last_seen=0");
@@ -350,5 +310,155 @@
   _apiClient.accessToken = token;
 
   XCTAssertEqualObjects([_apiClient getToken], token, "token not equal");
+}
+
+// surveyImmediately = YES
+- (void)testNeedsSurveyOne {
+  _apiClient.settings.surveyImmediately = YES;
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyImmediately = YES, surveyed = YES
+- (void)testNeedsSurveyTwo {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  _apiClient.settings.surveyImmediately = YES;
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// firstSurveyAfter = 31, externalCreatedAt = 32
+- (void)testNeedsSurveyThree {
+  _apiClient.settings.firstSurveyAfter = @31;
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:32]; // 32 days ago
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// firstSurveyAfter = 0, surveyed = N0
+- (void)testNeedsSurveyFour {
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:32]; // 32 days ago
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// firstSurveyAfter = 0, surveyed = YES
+- (void)testNeedsSurveyFive {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:32]; // 32 days ago
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// surveyed > 90 days, surveyed = YES
+- (void)testNeedsSurveySix {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setDouble:[[self createdDaysAgo:95] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed > 90 days, surveyed = YES, type = response
+- (void)testNeedsSurveySeven {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"response" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:95] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed < 90 days, surveyed = YES, type = response
+- (void)testNeedsSurveyEight {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"response" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:85] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// surveyed > 30 days, surveyed = YES, type = decline
+- (void)testNeedsSurveyNine {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"decline" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:35] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed < 30 days, surveyed = YES, type = decline
+- (void)testNeedsSurveyTen {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  [defaults setObject:@"decline" forKey:@"type"];
+  [defaults setDouble:[[self createdDaysAgo:25] doubleValue] forKey:@"surveyedAt"];
+  [WTRDefaults checkIfSurveyedDefaultExpired];
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 60, externalCreatedAt = 20, lastSeenAt = 40
+- (void)testNeedsSurveyEleven {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setDouble:[[self createdDaysAgo:40] doubleValue] forKey:@"lastSeenAt"];
+  _apiClient.settings.firstSurveyAfter = @60;
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:20];
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 31, externalCreatedAt = 20, lastSeenAt = 40
+- (void)testNeedsSurveyTwelve {
+  _apiClient.settings.firstSurveyAfter = @31;
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:20];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setDouble:[[self createdDaysAgo:40] doubleValue] forKey:@"lastSeenAt"];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 2, externalCreatedAt = 2, lastSeenAt = 4
+- (void)testNeedsSurveyThirteen {
+  _apiClient.settings.firstSurveyAfter = @2;
+  _apiClient.settings.externalCreatedAt = [self createdDaysAgo:2];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setDouble:[[self createdDaysAgo:4] doubleValue] forKey:@"lastSeenAt"];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed = YES, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = YES
+- (void)testNeedsSurveyFourteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  XCTAssertFalse([_apiClient needsSurvey]);
+}
+
+// surveyed = YES, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = NO
+- (void)testNeedsSurveyFifteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:YES forKey:@"surveyed"];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = YES
+- (void)testNeedsSurveySixteen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:NO forKey:@"surveyed"];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+// surveyed = NO, surveyImmediately = NO, firstSurveyAfter = 0, setDefaultAfterSurvey = NO
+- (void)testNeedsSurveySeventeen {
+  _apiClient.settings.firstSurveyAfter = @0;
+  _apiClient.settings.setDefaultAfterSurvey = NO;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setBool:NO forKey:@"surveyed"];
+  [defaults setDouble:[[self createdDaysAgo:4] doubleValue] forKey:@"lastSeenAt"];
+  XCTAssertTrue([_apiClient needsSurvey]);
+}
+
+- (NSNumber *)createdDaysAgo:(int)daysAgo {
+  return [NSNumber numberWithDouble:[[NSDate date] timeIntervalSince1970] - (daysAgo * 60 * 60 * 24)];
 }
 @end

--- a/WootricSDK/WootricSDKTests/WTRWootricTests.m
+++ b/WootricSDK/WootricSDKTests/WTRWootricTests.m
@@ -8,11 +8,11 @@
 
 #import <XCTest/XCTest.h>
 #import <WootricSDK/WootricSDK.h>
-#import "WTRApiClient.h"
+#import "WTRSurvey.h"
 
 @interface WTRWootricTests : XCTestCase
 
-@property (nonatomic, strong) WTRApiClient *apiClient;
+@property (nonatomic, strong) WTRSurvey *surveyClient;
 @property (nonatomic, strong) UIColor *color;
 
 @end
@@ -21,7 +21,7 @@
 
 - (void)setUp {
   [Wootric configureWithClientID:@"NPS-abc123" accountToken:@"abcdefg12345677"];
-  _apiClient = [WTRApiClient sharedInstance];
+  _surveyClient = [WTRSurvey sharedInstance];
   _color = [UIColor colorWithRed:0.1f green:0.2f blue:0.3f alpha:1.0f];
 }
 
@@ -29,161 +29,162 @@
   NSNumber *endUserCreatedAt = @123;
   [Wootric setEndUserCreatedAt:endUserCreatedAt];
   
-  XCTAssertEqualObjects(_apiClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
+  XCTAssertEqualObjects(_surveyClient.settings.externalCreatedAt, endUserCreatedAt, @"externalCreatedAt should be equal to 123");
 }
 
 - (void)testSetEndUserEmail {
   static NSString *endUserEmail = @"test@example.com";
   [Wootric setEndUserEmail:endUserEmail];
   
-  XCTAssertEqualObjects(_apiClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
+  XCTAssertEqualObjects(_surveyClient.settings.endUserEmail, endUserEmail, @"endUserEmail should be equal to test@example.com");
 }
 
 - (void)testSetProductNameForEndUser {
   static NSString *productName = @"Example";
   [Wootric setProductNameForEndUser:@"Example"];
   
-  XCTAssertEqualObjects(_apiClient.settings.productName, productName, @"productName should be equal to Example");
+  XCTAssertEqualObjects(_surveyClient.settings.productName, productName, @"productName should be equal to Example");
 }
 
 - (void)testSetCustomLanguage {
   static NSString *language = @"Epañol";
   [Wootric setCustomLanguage:language];
   
-  XCTAssertEqualObjects(_apiClient.settings.languageCode, language, @"languageCode should be equal to Español");
+  XCTAssertEqualObjects(_surveyClient.settings.languageCode, language, @"languageCode should be equal to Español");
 }
 
 - (void)testSetCustomAudience {
   static NSString *audience = @"Custom audience";
   [Wootric setCustomAudience:audience];
   
-  XCTAssertEqualObjects(_apiClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
+  XCTAssertEqualObjects(_surveyClient.settings.customAudience, audience, @"customAudience should be equal to Custom audience");
 }
 
 - (void)testSetCustomProductName {
   static NSString *customProductName = @"Custom product";
   [Wootric setCustomProductName:customProductName];
   
-  XCTAssertEqualObjects(_apiClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
+  XCTAssertEqualObjects(_surveyClient.settings.customProductName, customProductName, @"customProductName should be equal to Custom product");
 }
 
 - (void)testSetCustomFinalThankYou {
   static NSString *customFinalThankYou = @"CustomFinalThankYou";
   [Wootric setCustomFinalThankYou:customFinalThankYou];
-  XCTAssertEqualObjects(_apiClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
+  XCTAssertEqualObjects(_surveyClient.settings.customFinalThankYou, customFinalThankYou, @"customFinalThankYou should be equal to CustomFinalThankYou");
 }
 
 - (void)testSetCustomQuestion {
   static NSString *customQuestion = @"Would you recommend this to a friend?";
   [Wootric setCustomQuestion:customQuestion];
   
-  XCTAssertEqualObjects(_apiClient.settings.customQuestion, customQuestion, @"customQuestion should be equal to Would you recommend this to a friend?");
+  XCTAssertEqualObjects(_surveyClient.settings.customQuestion, customQuestion, @"customQuestion should be equal to Would you recommend this to a friend?");
 }
 
 - (void)testSetEndUserProperties {
   NSDictionary *endUserProperties = @{@"email": @"test@example.com"};
   [Wootric setEndUserProperties:endUserProperties];
   
-  XCTAssertEqualObjects(_apiClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
-  XCTAssertEqualObjects([_apiClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
+  XCTAssertEqualObjects(_surveyClient.settings.customProperties, endUserProperties, @"customProperties should be equal to @{@\"email\": @\"test@example.com\"}");
+  XCTAssertEqualObjects([_surveyClient.settings.customProperties objectForKey:@"email"], @"test@example.com", @"email should be equal to test@example.com");
 }
 
 - (void)testSetFirstSurveyAfter {
-  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
+  [Wootric setFirstSurveyAfter:@0];
+  XCTAssertEqualObjects(_surveyClient.settings.firstSurveyAfter, @0, @"firstSurveyAfter should be equal to 0");
   [Wootric setFirstSurveyAfter:@15];
-  XCTAssertEqualObjects(_apiClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
+  XCTAssertEqualObjects(_surveyClient.settings.firstSurveyAfter, @15, @"firstSurveyAfter should be equal to 15");
 }
 
 - (void)testSetSurveyedDefault {
-  XCTAssertTrue(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
+  XCTAssertTrue(_surveyClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be true");
   [Wootric setSurveyedDefault:NO];
-  XCTAssertFalse(_apiClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
+  XCTAssertFalse(_surveyClient.settings.setDefaultAfterSurvey, @"setDefaultAfterSurvey should be false");
 }
 
 - (void)testSurveyImmediately {
   [Wootric surveyImmediately:YES];
-  XCTAssertTrue(_apiClient.settings.surveyImmediately, @"surveyImmediately should be true");
+  XCTAssertTrue(_surveyClient.settings.surveyImmediately, @"surveyImmediately should be true");
   [Wootric surveyImmediately:NO];
-  XCTAssertFalse(_apiClient.settings.surveyImmediately, @"surveyImmediately should be false");
+  XCTAssertFalse(_surveyClient.settings.surveyImmediately, @"surveyImmediately should be false");
 }
 
 - (void)testForceSurvey {
   [Wootric forceSurvey:YES];
   
-  XCTAssertTrue(_apiClient.settings.forceSurvey, @"forceSurvey should be true");
+  XCTAssertTrue(_surveyClient.settings.forceSurvey, @"forceSurvey should be true");
 }
 
 - (void)testSkipFeedbackScreenForPromoter {
   [Wootric skipFeedbackScreenForPromoter:NO];
-  XCTAssertFalse(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be false");
+  XCTAssertFalse(_surveyClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be false");
   [Wootric skipFeedbackScreenForPromoter:YES];
-  XCTAssertTrue(_apiClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be true");
+  XCTAssertTrue(_surveyClient.settings.skipFeedbackScreenForPromoter, @"skipFeedbackScreenForPromoter should be true");
 }
 
 - (void)testSkipFeedbackScreen {
   [Wootric skipFeedbackScreen:NO];
-  XCTAssertFalse(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
+  XCTAssertFalse(_surveyClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be false");
   [Wootric skipFeedbackScreen:YES];
-  XCTAssertTrue(_apiClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
+  XCTAssertTrue(_surveyClient.settings.skipFeedbackScreen, @"skipFeedbackScreen should be true");
 }
 
 - (void)testPassScoreAndTextToURL {
   [Wootric passScoreAndTextToURL:NO];
   
-  XCTAssertFalse(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
+  XCTAssertFalse(_surveyClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be false");
   
   [Wootric passScoreAndTextToURL:YES];
   
-  XCTAssertTrue(_apiClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
+  XCTAssertTrue(_surveyClient.settings.passScoreAndTextToURL, @"passScoreAndTextToURL should be true");
 }
 
 - (void)testSetFacebookPage {
   NSURL *url = [NSURL URLWithString:@"facebook.com/test"];
   [Wootric setFacebookPage:url];
   
-  XCTAssertEqualObjects(_apiClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
+  XCTAssertEqualObjects(_surveyClient.settings.facebookPage, url, @"facebookPage should be facebook.com/test");
 }
 
 - (void)testSetTwitterHandler {
   static NSString *twitterHandler = @"twitter";
   [Wootric setTwitterHandler:twitterHandler];
   
-  XCTAssertEqualObjects(_apiClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
+  XCTAssertEqualObjects(_surveyClient.settings.twitterHandler, twitterHandler, @"twitterHandler should be twitter");
 }
 
 - (void)testSetSendButtonBackgroundColor {
   [Wootric setSendButtonBackgroundColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.sendButtonBackgroundColor, _color, @"sendButtonBackgroundColor should equal to color");
 }
 
 - (void)testSetSliderColor {
   [Wootric setSliderColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.sliderColor, _color, @"sliderColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.sliderColor, _color, @"sliderColor should equal to color");
 }
 
 - (void)testSetThankYouButtonBackgroundColor {
   [Wootric setThankYouButtonBackgroundColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.thankYouButtonBackgroundColor, _color, @"thankYouButtonBackgroundColor should equal to color");
 }
 
 - (void)testSetSocialSharingColor {
   [Wootric setSocialSharingColor:_color];
   
-  XCTAssertEqualObjects(_apiClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
+  XCTAssertEqualObjects(_surveyClient.settings.socialSharingColor, _color, @"socialSharingColor should equal to color");
 }
 
 - (void)testShowOptOutDefaultNo {
-  XCTAssertFalse(_apiClient.settings.showOptOut, @"showOptOut default value should be NO");
+  XCTAssertFalse(_surveyClient.settings.showOptOut, @"showOptOut default value should be NO");
 }
 
 - (void)testSetShowOptOut {
   [Wootric showOptOut:YES];
   
-  XCTAssertTrue(_apiClient.settings.showOptOut, @"showOptOut default value should be YES");
-  _apiClient.settings.showOptOut = NO;
+  XCTAssertTrue(_surveyClient.settings.showOptOut, @"showOptOut default value should be YES");
+  _surveyClient.settings.showOptOut = NO;
 }
 
 @end


### PR DESCRIPTION
Add support to handle events. This would bring full support of `Targeted Sampling` to iOS. The goal is to be able to call the SDK with an event name and let the server decide if the end user combined with the event name and properties make the user eligible to be surveyed. The implementation adds an `NSOperationQueue` to handle the events being called in a `FIFO` way.

## Changes
- Add custom implementation of `NSOperation`
- Refactor code to handle multiple calls
- Update and add tests

## Test

- Set up `Targeted Sampling` in one account
- Call survey with the event name and properties to trigger the survey

```objective-c
  NSString *clientID = @"YOUR_CLIENT_ID";
  NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";

  [Wootric configureWithClientID:clientID accountToken:accountToken];
  [Wootric setEndUserEmail:@"END_USER_EMAIL"];
  [Wootric setEndUserCreatedAt:@1234567890];
  [Wootric setEndUserProperties:@{ @"property1": @"value1", @"property2": @"value2"}];


  [Wootric showSurveyInViewController:self event:@"Button Click"];
```

Try calling this multiple times with different values, the SDK should handle the different calls separately (even try different calls with different `endUserEmail`, `endUserProperties` and `eventName`).

Once the server returns `true`, all subsequent calls should be cancelled and the survey should be shown with the correct values.

- Test this on both iPhone and iPad