### PR TITLE
Fix follow-up Thank You/Placeholder text not appearing in UI

### DIFF
--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -1002,6 +1002,8 @@
   settingsCopy.sendButtonBackgroundColor = self.sendButtonBackgroundColor;
   settingsCopy.sliderColor = self.sliderColor;
   settingsCopy.socialSharingColor = self.socialSharingColor;
+  settingsCopy.userCustomThankYou = self.userCustomThankYou;
+  settingsCopy.userCustomMessages = self.userCustomMessages;
   
   return settingsCopy;
 }


### PR DESCRIPTION
You can specify follow-up Thank You/Placeholder right now, but it never appears in UI. 

That happens due to the fact that `userCustomThankYou`/`userCustomMessages` are not copied over to new instances of `WTRSettings`.

In `Wootric#showSurveyInViewController:`, `WTRSurvey#survey:` is called, where a copy of WTRSettings is created. This copy is then used to present survey in view controller.

I don't know if there was a reason for that, and if this PR can break anything. But the problem is that custom follow up text is not working right now.