### PR TITLE
Fix settings copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ xcuserdata/
 *.playground
 
 .DS_Store
+bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.18.1 (2020-07-07)
+
+### Changes:
+
+- Fix copy for CustomMessages, CustomSocial, CustomThankYou and LocalizedText objects
+
 ## 0.18.0 (2020-05-29)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.18.0"
+	pod "WootricSDK", "~> 0.18.1"
 	```
 
 3. In your Xcode project directory run the following command:
@@ -61,11 +61,11 @@ WootricSDK task is to present a fully functional survey view with just a few lin
 	#import <WootricSDK/WootricSDK.h>
 	```
 
-2. Configure the SDK with your client ID and account token
+2. Configure the SDK with your account token
 	```objective-c
-	[Wootric configureWithClientID:<YOUR_CLIENT_ID> accountToken:<YOUR_TOKEN>];
+	[Wootric configureWithAccountToken:<YOUR_TOKEN>];
 	``` 
-	*You can find the client ID on your [Wootric's account settings](https://app.wootric.com/account_settings/edit?) on the API section.*
+	*You can find the account token in your [Wootric's account settings](https://app.wootric.com/account_settings/edit?#!/account)*
 
 3. To display the survey (if user is eligible - this check is built in the method) use:
 	```objective-c
@@ -84,7 +84,7 @@ For more information on class methods, please refer to [Wootric's docs](http://c
 
 // Inside your view controller's viewDidLoad method
 
-[Wootric configureWithClientID:YOUR_CLIENT_ID accountToken:YOUR_ACCOUNT_TOKEN];
+[Wootric configureWithAccountToken:YOUR_ACCOUNT_TOKEN];
 [Wootric setEndUserEmail:@"nps@example.com"];
 [Wootric setEndUserCreatedAt:@1234567890];
 // Use only for testing

--- a/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
+++ b/WootricSDK-Demo/WootricSDK-Demo/ViewController.m
@@ -37,10 +37,9 @@
 }
 
 - (IBAction)startSurvey:(UIButton *)sender {
-  NSString *clientID = @"YOUR_CLIENT_ID";
   NSString *accountToken = @"YOUR_ACCOUNT_TOKEN";
 
-  [Wootric configureWithClientID:clientID accountToken:accountToken];
+  [Wootric configureWithAccountToken:accountToken];
   [Wootric setEndUserEmail:@"END_USER_EMAIL"];
   [Wootric setEndUserCreatedAt:@1234567890];
 

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.18.0'
+  s.version  = '0.18.1'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -917,7 +917,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 0.18.0;
+				MARKETING_VERSION = 0.18.1;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -939,7 +939,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 0.18.0;
+				MARKETING_VERSION = 0.18.1;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/WootricSDK/WootricSDK/WTRCustomMessages.h
+++ b/WootricSDK/WootricSDK/WTRCustomMessages.h
@@ -36,5 +36,6 @@
 @property (nonatomic, strong) NSString *promoterText;
 
 - (instancetype)initWithCustomMessages:(NSDictionary *)customMessages;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRCustomMessages.m
+++ b/WootricSDK/WootricSDK/WTRCustomMessages.m
@@ -54,4 +54,16 @@
   return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRCustomMessages *customMessagesCopy = [[WTRCustomMessages allocWithZone:zone] init];
+  customMessagesCopy.followupQuestion = self.followupQuestion;
+  customMessagesCopy.detractorQuestion = self.detractorQuestion;
+  customMessagesCopy.passiveQuestion = self.passiveQuestion;
+  customMessagesCopy.promoterQuestion = self.promoterQuestion;
+  customMessagesCopy.followupText = self.followupText;
+  customMessagesCopy.detractorText = self.detractorText;
+  customMessagesCopy.passiveText = self.passiveText;
+  customMessagesCopy.promoterText = self.promoterText;
+  return customMessagesCopy;
+}
 @end

--- a/WootricSDK/WootricSDK/WTRCustomSocial.h
+++ b/WootricSDK/WootricSDK/WTRCustomSocial.h
@@ -31,5 +31,6 @@
 
 - (instancetype)initWithCustomSocial:(NSDictionary *)customSocial;
 - (BOOL)socialEnabled;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRCustomSocial.m
+++ b/WootricSDK/WootricSDK/WTRCustomSocial.m
@@ -49,4 +49,10 @@
   return isSocialEnabled;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRCustomSocial *customSocialCopy = [[WTRCustomSocial allocWithZone:zone] init];
+  customSocialCopy.twitterHandler = self.twitterHandler;
+  customSocialCopy.facebookPage = self.facebookPage;
+  return customSocialCopy;
+}
 @end

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.h
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.h
@@ -57,5 +57,6 @@
 
 - (instancetype)initWithCustomThankYou:(NSDictionary *)customThankYou;
 - (BOOL)hasShareConfiguration;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRCustomThankYou.m
@@ -85,4 +85,36 @@
   return (_promoterThankYouLinkText && _promoterThankYouLinkURL);
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRCustomThankYou *customThankYouCopy = [[WTRCustomThankYou allocWithZone:zone] init];
+  customThankYouCopy.thankYouMain = self.thankYouMain;
+  customThankYouCopy.thankYouSetup = self.thankYouSetup;
+  customThankYouCopy.detractorThankYouMain = self.detractorThankYouMain;
+  customThankYouCopy.detractorThankYouSetup = self.detractorThankYouSetup;
+  customThankYouCopy.passiveThankYouMain = self.passiveThankYouMain;
+  customThankYouCopy.passiveThankYouSetup = self.passiveThankYouSetup;
+  customThankYouCopy.promoterThankYouMain = self.promoterThankYouMain;
+  customThankYouCopy.promoterThankYouSetup = self.promoterThankYouSetup;
+  customThankYouCopy.thankYouLinkText = self.thankYouLinkText;
+  customThankYouCopy.thankYouLinkURL = self.thankYouLinkURL;
+  customThankYouCopy.detractorThankYouLinkText = self.detractorThankYouLinkText;
+  customThankYouCopy.detractorThankYouLinkURL = self.detractorThankYouLinkURL;
+  customThankYouCopy.passiveThankYouLinkText = self.passiveThankYouLinkText;
+  customThankYouCopy.passiveThankYouLinkURL = self.passiveThankYouLinkURL;
+  customThankYouCopy.promoterThankYouLinkText = self.promoterThankYouLinkText;
+  customThankYouCopy.promoterThankYouLinkURL = self.promoterThankYouLinkURL;
+  customThankYouCopy.isEmailInURL = self.isEmailInURL;
+  customThankYouCopy.isDetractorEmailInURL = self.isDetractorEmailInURL;
+  customThankYouCopy.isPassiveEmailInURL = self.isPassiveEmailInURL;
+  customThankYouCopy.isPromoterEmailInURL = self.isPromoterEmailInURL;
+  customThankYouCopy.isScoreInURL = self.isScoreInURL;
+  customThankYouCopy.isDetractorScoreInURL = self.isDetractorScoreInURL;
+  customThankYouCopy.isPassiveScoreInURL = self.isPassiveScoreInURL;
+  customThankYouCopy.isPromoterScoreInURL = self.isPromoterScoreInURL;
+  customThankYouCopy.isCommentInURL = self.isCommentInURL;
+  customThankYouCopy.isDetractorCommentInURL = self.isDetractorCommentInURL;
+  customThankYouCopy.isPassiveCommentInURL = self.isPassiveCommentInURL;
+  customThankYouCopy.isPromoterCommentInURL = self.isPromoterCommentInURL;
+  return customThankYouCopy;
+}
 @end

--- a/WootricSDK/WootricSDK/WTRLocalizedTexts.h
+++ b/WootricSDK/WootricSDK/WTRLocalizedTexts.h
@@ -39,5 +39,6 @@
 @property (nonatomic, strong) NSString *socialShareDecline;
 
 - (instancetype)initWithLocalizedTexts:(NSDictionary *)localizedTexts;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRLocalizedTexts.m
+++ b/WootricSDK/WootricSDK/WTRLocalizedTexts.m
@@ -55,4 +55,19 @@
   return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRLocalizedTexts *localizedTextsCopy = [[WTRLocalizedTexts allocWithZone:zone] init];
+  localizedTextsCopy.question = self.question;
+  localizedTextsCopy.likelyAnchor = self.likelyAnchor;
+  localizedTextsCopy.notLikelyAnchor = self.notLikelyAnchor;
+  localizedTextsCopy.followupQuestion = self.followupQuestion;
+  localizedTextsCopy.followupPlaceholder = self.followupPlaceholder;
+  localizedTextsCopy.finalThankYou = self.finalThankYou;
+  localizedTextsCopy.send = self.send;
+  localizedTextsCopy.dismiss = self.dismiss;
+  localizedTextsCopy.editScore = self.editScore;
+  localizedTextsCopy.socialShareQuestion = self.socialShareQuestion;
+  localizedTextsCopy.socialShareDecline = self.socialShareDecline;
+  return localizedTextsCopy;
+}
 @end

--- a/WootricSDK/WootricSDK/WTRSettings.m
+++ b/WootricSDK/WootricSDK/WTRSettings.m
@@ -964,7 +964,7 @@
   }
 }
 
--(id)copyWithZone:(NSZone *)zone{
+- (id)copyWithZone:(NSZone *)zone {
   WTRSettings *settingsCopy = [[WTRSettings allocWithZone:zone] init];
 
   settingsCopy.endUserEmail = self.endUserEmail;
@@ -1002,6 +1002,14 @@
   settingsCopy.sendButtonBackgroundColor = self.sendButtonBackgroundColor;
   settingsCopy.sliderColor = self.sliderColor;
   settingsCopy.socialSharingColor = self.socialSharingColor;
+  
+  settingsCopy.localizedTexts = [self.localizedTexts copy];
+  settingsCopy.customMessages = [self.customMessages copy];
+  settingsCopy.customThankYou = [self.customThankYou copy];
+  settingsCopy.customSocial = [self.customSocial copy];
+  settingsCopy.userCustomMessages = [self.userCustomMessages copy];
+  settingsCopy.userCustomThankYou = [self.userCustomThankYou copy];
+  settingsCopy.userCustomSocial = [self.userCustomSocial copy];
   
   return settingsCopy;
 }

--- a/WootricSDK/WootricSDK/WTRUserCustomMessages.h
+++ b/WootricSDK/WootricSDK/WTRUserCustomMessages.h
@@ -37,5 +37,6 @@
 
 - (BOOL)userCustomQuestionPresent;
 - (BOOL)userCustomPlaceholderPresent;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRUserCustomMessages.m
+++ b/WootricSDK/WootricSDK/WTRUserCustomMessages.m
@@ -42,4 +42,16 @@
   return NO;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRUserCustomMessages *userCustomMessagesCopy = [[WTRUserCustomMessages allocWithZone:zone] init];
+  userCustomMessagesCopy.followupQuestion = self.followupQuestion;
+  userCustomMessagesCopy.detractorQuestion = self.detractorQuestion;
+  userCustomMessagesCopy.passiveQuestion = self.passiveQuestion;
+  userCustomMessagesCopy.promoterQuestion = self.promoterQuestion;
+  userCustomMessagesCopy.placeholderText = self.placeholderText;
+  userCustomMessagesCopy.detractorPlaceholderText = self.detractorPlaceholderText;
+  userCustomMessagesCopy.passivePlaceholderText = self.passivePlaceholderText;
+  userCustomMessagesCopy.promoterPlaceholderText = self.promoterPlaceholderText;
+  return userCustomMessagesCopy;
+}
 @end

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.h
@@ -61,5 +61,6 @@
 - (BOOL)userCustomThankYouSetupPresent;
 - (BOOL)userCustomLinkPresent;
 - (BOOL)hasShareConfiguration;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end

--- a/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
+++ b/WootricSDK/WootricSDK/WTRUserCustomThankYou.m
@@ -73,4 +73,37 @@
   return (_promoterThankYouLinkText && _promoterThankYouLinkURL);
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  WTRUserCustomThankYou *userCustomThankYouCopy = [[WTRUserCustomThankYou allocWithZone:zone] init];
+  userCustomThankYouCopy.thankYouMain = self.thankYouMain;
+  userCustomThankYouCopy.thankYouSetup = self.thankYouSetup;
+  userCustomThankYouCopy.detractorThankYouMain = self.detractorThankYouMain;
+  userCustomThankYouCopy.detractorThankYouSetup = self.detractorThankYouSetup;
+  userCustomThankYouCopy.passiveThankYouMain = self.passiveThankYouMain;
+  userCustomThankYouCopy.passiveThankYouSetup = self.passiveThankYouSetup;
+  userCustomThankYouCopy.promoterThankYouMain = self.promoterThankYouMain;
+  userCustomThankYouCopy.promoterThankYouSetup = self.promoterThankYouSetup;
+  userCustomThankYouCopy.thankYouLinkText = self.thankYouLinkText;
+  userCustomThankYouCopy.thankYouLinkURL = self.thankYouLinkURL;
+  userCustomThankYouCopy.detractorThankYouLinkText = self.detractorThankYouLinkText;
+  userCustomThankYouCopy.detractorThankYouLinkURL = self.detractorThankYouLinkURL;
+  userCustomThankYouCopy.passiveThankYouLinkText = self.passiveThankYouLinkText;
+  userCustomThankYouCopy.passiveThankYouLinkURL = self.passiveThankYouLinkURL;
+  userCustomThankYouCopy.promoterThankYouLinkText = self.promoterThankYouLinkText;
+  userCustomThankYouCopy.promoterThankYouLinkURL = self.promoterThankYouLinkURL;
+  userCustomThankYouCopy.backgroundColor = self.backgroundColor;
+  userCustomThankYouCopy.isEmailInURL = self.isEmailInURL;
+  userCustomThankYouCopy.isDetractorEmailInURL = self.isDetractorEmailInURL;
+  userCustomThankYouCopy.isPassiveEmailInURL = self.isPassiveEmailInURL;
+  userCustomThankYouCopy.isPromoterEmailInURL = self.isPromoterEmailInURL;
+  userCustomThankYouCopy.isScoreInURL = self.isScoreInURL;
+  userCustomThankYouCopy.isDetractorScoreInURL = self.isDetractorScoreInURL;
+  userCustomThankYouCopy.isPassiveScoreInURL = self.isPassiveScoreInURL;
+  userCustomThankYouCopy.isPromoterScoreInURL = self.isPromoterScoreInURL;
+  userCustomThankYouCopy.isCommentInURL = self.isCommentInURL;
+  userCustomThankYouCopy.isDetractorCommentInURL = self.isDetractorCommentInURL;
+  userCustomThankYouCopy.isPassiveCommentInURL = self.isPassiveCommentInURL;
+  userCustomThankYouCopy.isPromoterCommentInURL = self.isPromoterCommentInURL;
+  return userCustomThankYouCopy;
+}
 @end


### PR DESCRIPTION
Add missing copy method for CustomMessages, CustomSocial, CustomThankYou and LocalizedText object.

## Changes

- Add copy methods to `CustomMessages`, `CustomSocial`, `CustomThankYou` and `LocalizedText`
- Update method used in `WootricSDK-Demo/WootricSDK-Demo/ViewController.m`
 
## Test

1. Create project and setup Wootric
2. Set a custom thank you

```obj_c
[Wootric setPromoterThankYouLinkWithText:@"Link text" URL:[NSURL URLWithString:@"https://wootric.com"]];
```
3. Button should appear correctly on the third screen.