### PR TITLE
Fix authenticate when get/post end_users fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.18.2 (2020-08-11)
+
+### Changes:
+
+- Fix authenticate bug
+- Fix User-Agent in all requests
+
 ## 0.18.1 (2020-07-07)
 
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to get Wootric into your iOS project is to use [CocoaPods](http:
 
 2. Create a file in your Xcode project called Podfile and add the following line:
 	```ruby
-	pod "WootricSDK", "~> 0.18.1"
+	pod "WootricSDK", "~> 0.18.2"
 	```
 
 3. In your Xcode project directory run the following command:

--- a/WootricSDK.podspec
+++ b/WootricSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'WootricSDK'
-  s.version  = '0.18.1'
+  s.version  = '0.18.2'
   s.license  = 'MIT'
   s.summary  = 'Wootric SDK for displaying survey for end user.'
   s.homepage = 'https://github.com/Wootric/WootricSDK-iOS'

--- a/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
+++ b/WootricSDK/WootricSDK.xcodeproj/project.pbxproj
@@ -917,7 +917,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 0.18.1;
+				MARKETING_VERSION = 0.18.2;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -939,7 +939,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 0.18.1;
+				MARKETING_VERSION = 0.18.2;
 				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/WootricSDK/WootricSDK/WTRApiClient.h
+++ b/WootricSDK/WootricSDK/WTRApiClient.h
@@ -34,7 +34,7 @@
 
 + (instancetype)sharedInstance;
 - (void)getRegisteredEventList:(void (^)(NSArray *))completionHandler;
-- (void)authenticate:(void (^)(void))completionHandler;
+- (void)authenticate:(void (^)(BOOL))completionHandler;
 - (void)checkEligibility:(void (^)(BOOL))completionHandler;
 - (void)endUserDeclined;
 - (void)endUserVotedWithScore:(NSInteger)score andText:(NSString *)text;

--- a/WootricSDK/WootricSDK/WTREvent.m
+++ b/WootricSDK/WootricSDK/WTREvent.m
@@ -78,8 +78,8 @@
 - (void)checkEligibility:(WTRApiClient *)apiClient {
   [apiClient checkEligibility:^(BOOL eligible){
     if (eligible) {
-      [apiClient authenticate:^{
-        self.completion(apiClient.settings);
+      [apiClient authenticate:^(BOOL succeeded){
+        self.completion(succeeded? apiClient.settings : nil);
         [self finish];
       }];
     } else {

--- a/WootricSDK/WootricSDKTests/WTRApiClientTests.m
+++ b/WootricSDK/WootricSDKTests/WTRApiClientTests.m
@@ -54,7 +54,7 @@ static NSString *const WTRAPIVersion = @"api/v1";
 - (NSMutableURLRequest *)requestWithURL:(NSURL *)url HTTPMethod:(NSString *)httpMethod andHTTPBody:(NSString *)httpBody;
 - (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID;
 - (void)getEndUserWithEmail:(void (^)(NSInteger endUserID))endUserWithID;
-- (void)authenticate:(void (^)(void))authenticated;
+- (void)authenticate:(void (^)(BOOL))authenticated;
 - (NSString *)paramsWithScore:(NSInteger)score endUserID:(long)endUserID accountID:(NSNumber *)accountID uniqueLink:(nonnull NSString *)uniqueLink priority:(int)priority text:(nullable NSString *)text;
 - (NSString *)randomString;
 - (NSString *)buildUniqueLinkAccountToken:(NSString *)accountToken endUserEmail:(NSString *)endUserEmail date:(NSTimeInterval)date randomString:(NSString *)randomString;
@@ -168,6 +168,7 @@ static NSString *const WTRAPIVersion = @"api/v1";
   _apiClient.accessToken = @"accessToken";
   urlRequest = [_apiClient requestWithURL:url HTTPMethod:nil andHTTPBody:nil];
   XCTAssertEqualObjects([urlRequest valueForHTTPHeaderField:@"Authorization"], @"Bearer accessToken");
+  XCTAssertEqualObjects([urlRequest valueForHTTPHeaderField:@"User-Agent"], @"Wootric-Mobile-SDK");
   
   NSString *httpBody = [[NSString alloc] initWithData:urlRequest.HTTPBody encoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(httpBody, @"");
@@ -217,10 +218,9 @@ static NSString *const WTRAPIVersion = @"api/v1";
   NSTimeInterval date = 1234567890;
   
   XCTAssertEqualObjects([_apiClient buildUniqueLinkAccountToken:_apiClient.accountToken
-                                            endUserEmail:_apiClient.settings.endUserEmail
-                                                    date:date
-                                            randomString:randomString],
-                 @"1ed9f1c96018e2d577b3f864dc59dffe2baccc7103f6dcdadc40c3b6ec98cb0b");
+                                                   endUserEmail:_apiClient.settings.endUserEmail
+                                                           date:date
+                                                   randomString:randomString], @"1ed9f1c96018e2d577b3f864dc59dffe2baccc7103f6dcdadc40c3b6ec98cb0b");
 }
 
 - (void)testResponseParams {


### PR DESCRIPTION
When GET/POST to /api/v1/end_users fails, do not show survey.

## Changes

- Fix authenticate method
- Set User-Agent "Wootric-Mobile-SDK" in all requests

## Test

To replicate bug on master, create new end user with incorrect property

```obj-c
  [Wootric configureWithAccountToken:accountToken];
  [Wootric setEndUserEmail:@"test@example.com"];;

  [Wootric setEndUserProperties:@{
    @"incorrect_property_date": @"2020-01-01"
  }];

  [Wootric showSurveyInViewController:self];
```

Now checkout this branch, if an error occurs, the survey shouldn't show up and you should see an error in the logs.
