### PR TITLE
Safely serialise update end user network response

### DIFF
--- a/WootricSDK/WootricSDK/WTRApiClient.m
+++ b/WootricSDK/WootricSDK/WTRApiClient.m
@@ -179,23 +179,27 @@ static NSString *const WTRAPIVersion = @"api/v1";
 
   params = [self addVersionsToURLString:params];
 
-  if (needsUpdate) {
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/end_users/%ld?%@", WTRBaseAPIURL, WTRAPIVersion, (long)endUserID, params]];
-    NSMutableURLRequest *urlRequest = [self requestWithURL:url HTTPMethod:@"PUT" andHTTPBody:nil];
+    if (needsUpdate) {
+      NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/end_users/%ld?%@", WTRBaseAPIURL, WTRAPIVersion, (long)endUserID, params]];
+      NSMutableURLRequest *urlRequest = [self requestWithURL:url HTTPMethod:@"PUT" andHTTPBody:nil];
 
-    NSURLSessionDataTask *dataTask = [_wootricSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-      id responseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-      NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-      if (httpResponse.statusCode == 200) {
-        [WTRLogger log:@"(update end user): user updated"];
-        self->_endUserAlreadyUpdated = YES;
-      } else {
-        [WTRLogger logError:@"(update end user): %@", responseJSON];
-      }
-    }];
-    
-    [dataTask resume];
-  }
+        NSURLSessionDataTask *dataTask = [_wootricSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (error) {
+                [WTRLogger logError:@"(update end user): %@", error];
+            } else {
+                id responseJSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                if (httpResponse.statusCode == 200) {
+                    [WTRLogger log:@"(update end user): user updated"];
+                    self->_endUserAlreadyUpdated = YES;
+                } else {
+                    [WTRLogger logError:@"(update end user): %@", responseJSON];
+                }
+            }
+        }];
+
+        [dataTask resume];
+    }
 }
 
 - (void)createEndUser:(void (^)(NSInteger endUserID))endUserWithID {


### PR DESCRIPTION
**Issue**

We have had crash reports from users from the Wootric SDK, specifically from the `[WTRApiClient updateExistingEndUser:]` method with the exception `data parameter is nil` (see screenshot attached). On further investigation by the team we discovered that unlike other network requests in `WTRApiClient` there is no check if there is an `error` before attempting to serialise the data. We believe this is why the app is crashing. 

**Solution**
Following the format of other network requests in `WTRApiClient`, we check to see if there is an error before attempting to serialise the data. If `error` is nonnull, then this error is logged. This should prevent the occurrence of the `data parameter is nil` exception. 

Credit to @larromba for this solution. 

<img width="1304" alt="Screenshot 2020-12-16 at 16 23 06" src="https://user-images.githubusercontent.com/3322409/102375946-01689f00-3fbb-11eb-8fe5-efbd29e72b0e.png">
