### PR TITLE
Add option to hide open-ended text box when Picklist is active

### DIFF
--- a/WootricSDK/WootricSDK/WTRFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRFeedbackView.m
@@ -84,8 +84,12 @@
   if (driverPicklistSettings[@"dpl_randomize_list"] && [driverPicklistSettings[@"dpl_randomize_list"] intValue] == 1) {
     _driverPicklistKeys = [self shuffleArray:_driverPicklistKeys];
   }
-  if (driverPicklistSettings[@"dpl_hide_open_ended"]) {
-    // TODO: add support dpl_hide_open_ended
+  if (driverPicklistSettings[@"dpl_hide_open_ended"] && [driverPicklistSettings[@"dpl_hide_open_ended"] intValue] == 1) {
+    _feedbackTextView.hidden = true;
+    _feedbackPlaceholder.hidden = true;
+  } else {
+    _feedbackTextView.hidden = false;
+    _feedbackPlaceholder.hidden = false;
   }
   if (driverPicklistSettings[@"dpl_multi_select"]) {
     _multiselect = [driverPicklistSettings[@"dpl_multi_select"] boolValue];

--- a/WootricSDK/WootricSDK/WTRSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRSurveyViewController.m
@@ -208,17 +208,21 @@
   if (_feedbackView.hidden) {
     if ([_settings driverPicklistAnswers]) {
       [self updateConstraintModalHeight:308];
-      [self setModalGradient:_modalView.bounds];
-      [_modalView.layer insertSublayer:_gradient atIndex:0];
     }
   } else {
     if ([_settings driverPicklistAnswers]) {
       int numberOfRows = [_feedbackView numberOfRows];
-      [self updateConstraintModalHeight:(308 + (numberOfRows * 43)) feedbackViewHeight:(213 + (numberOfRows * 43))];
-      [self setModalGradient:_modalView.bounds];
-      [_modalView.layer insertSublayer:_gradient atIndex:0];
+      NSDictionary *driverPicklistSettings = [_settings driverPicklistSettingsForScore:_currentScore];
+      if (driverPicklistSettings[@"dpl_hide_open_ended"] && [driverPicklistSettings[@"dpl_hide_open_ended"] intValue] == 1) {
+        [self updateConstraintModalHeight:(160 + (numberOfRows * 43)) feedbackViewHeight:(213 + (numberOfRows * 43))];
+      } else {
+        [self updateConstraintModalHeight:(308 + (numberOfRows * 43)) feedbackViewHeight:(213 + (numberOfRows * 43))];
+      }
     }
   }
+  
+  [self setModalGradient:_modalView.bounds];
+  [_modalView.layer insertSublayer:_gradient atIndex:0];
 }
 
 - (void)presentShareScreenOrDismissForScore:(int)score {

--- a/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
+++ b/WootricSDK/WootricSDK/WTRiPADFeedbackView.m
@@ -41,6 +41,7 @@
 @property (nonatomic, strong) NSDictionary *driverPicklist;
 @property (nonatomic, strong) NSArray *driverPicklistKeys;
 @property BOOL multiselect;
+@property (nonatomic, strong) NSLayoutConstraint *driverPicklistBottomConstraint;
 @end
 
 @implementation WTRiPADFeedbackView
@@ -84,11 +85,24 @@
   if (driverPicklistSettings[@"dpl_randomize_list"] && [driverPicklistSettings[@"dpl_randomize_list"] intValue] == 1) {
     _driverPicklistKeys = [self shuffleArray:_driverPicklistKeys];
   }
-  if (driverPicklistSettings[@"dpl_hide_open_ended"]) {
-    // TODO: add dpl_hide_open_ended logic
+  if (driverPicklistSettings[@"dpl_hide_open_ended"] && [driverPicklistSettings[@"dpl_hide_open_ended"] intValue] == 1) {
+    _feedbackTextView.hidden = true;
+    _feedbackPlaceholder.hidden = true;
+    _sendButton.hidden = true;
+    _driverPicklistBottomConstraint.constant = -4;
+  } else {
+    _feedbackTextView.hidden = false;
+    _feedbackPlaceholder.hidden = false;
+    _sendButton.hidden = false;
+    _driverPicklistBottomConstraint.constant = -51;
   }
   if (driverPicklistSettings[@"dpl_multi_select"]) {
     _multiselect = [driverPicklistSettings[@"dpl_multi_select"] boolValue];
+  }
+  if ([_driverPicklistKeys count] > 0) {
+    [_driverPicklistCollectionView setHidden:false];
+  } else {
+    [_driverPicklistCollectionView setHidden:true];
   }
   [_driverPicklistCollectionView reloadData];
 }
@@ -187,7 +201,8 @@
   [[[[_driverPicklistCollectionView wtr_leftConstraint] toSecondViewLeft:self] withConstant:16] addToView:self];
   [[[[_driverPicklistCollectionView wtr_rightConstraint] toSecondViewRight:self] withConstant:-16] addToView:self];
   [[[[_driverPicklistCollectionView wtr_topConstraint] toSecondViewBottom:_followupLabel] withConstant:8] addToView:self];
-  [[[[_driverPicklistCollectionView wtr_bottomConstraint] toSecondViewTop:_feedbackTextView] withConstant:-4] addToView:self];
+  _driverPicklistBottomConstraint = [[[_driverPicklistCollectionView wtr_bottomConstraint] toSecondViewBottom:self] withConstant:-4];
+  [_driverPicklistBottomConstraint addToView:self];
 }
 
 - (void)setupFeedbackTextViewConstraints {

--- a/WootricSDK/WootricSDK/WTRiPADQuestionView.h
+++ b/WootricSDK/WootricSDK/WTRiPADQuestionView.h
@@ -34,5 +34,6 @@
 - (void)setupSubviewsConstraints;
 - (void)selectCircleButton:(WTRCircleScoreButton *)button;
 - (void)hideQuestionLabel;
+- (void)showSendButton:(BOOL)show;
 
 @end

--- a/WootricSDK/WootricSDK/WTRiPADQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRiPADQuestionView.m
@@ -35,6 +35,7 @@
 @property (nonatomic, strong) UILabel *notLikelyAnchor;
 @property (nonatomic, strong) WTRCircleScoreView *scoreView;
 @property (nonatomic, strong) WTRSettings *settings;
+@property (nonatomic, strong) UIButton *sendButton;
 
 @end
 
@@ -54,6 +55,7 @@
   [self setupLikelyAnchor];
   [self setupNotLikelyAnchor];
   [self setupCircleScoreViewWithViewController:viewController];
+  [self setupSendButtonViewWithViewController:viewController];
   [self addSubviews];
 }
 
@@ -62,6 +64,7 @@
   [self setupScoreViewConstraints];
   [self setupLikelyAnchorConstraints];
   [self setupNotLikelyAnchorConstraints];
+  [self setupSendButtonConstraints];
 }
 
 - (void)addSubviews {
@@ -69,14 +72,34 @@
   [self addSubview:_scoreView];
   [self addSubview:_likelyAnchor];
   [self addSubview:_notLikelyAnchor];
+  [self addSubview:_sendButton];
 }
 
 - (void)hideQuestionLabel {
   _questionLabel.hidden = YES;
 }
 
+- (void)showSendButton:(BOOL)show {
+  _sendButton.hidden = !show;
+}
+
 - (void)selectCircleButton:(WTRCircleScoreButton *)button {
   [_scoreView selectCircleButton:button];
+}
+
+- (void)setupSendButtonViewWithViewController:(UIViewController *)viewController {
+  _sendButton = [[UIButton alloc] init];
+  _sendButton.backgroundColor = [WTRColor iPadSendButtonBackgroundColor];
+  _sendButton.layer.cornerRadius = 3;
+  _sendButton.hidden = true;
+  _sendButton.titleLabel.font = [UIItems boldFontWithSize:14];
+  [_sendButton setTranslatesAutoresizingMaskIntoConstraints:NO];
+  [_sendButton setTitle:[self.settings sendButtonText] forState:UIControlStateNormal];
+  [_sendButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [_sendButton setTitleColor:[UIColor whiteColor] forState:UIControlStateDisabled];
+  [_sendButton addTarget:viewController
+                  action:NSSelectorFromString(@"sendButtonPressed")
+        forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)setupLikelyAnchorConstraints {
@@ -118,6 +141,20 @@
 - (void)setupScoreViewConstraints {
   [[[_scoreView wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
   [[[[_scoreView wtr_topConstraint] toSecondViewBottom:_questionLabel] withConstant:20] addToView:self];
+}
+
+- (void)setupSendButtonConstraints {
+  [_sendButton wtr_constraintWidth:132];
+  NSLayoutConstraint *constH = [NSLayoutConstraint constraintWithItem:_sendButton
+                                                            attribute:NSLayoutAttributeHeight
+                                                            relatedBy:NSLayoutRelationEqual
+                                                               toItem:nil
+                                                            attribute:NSLayoutAttributeNotAnAttribute
+                                                           multiplier:1
+                                                             constant:32];
+  [_sendButton addConstraint:constH];
+  [[[_sendButton wtr_centerXConstraint] toSecondViewCenterX:self] addToView:self];
+  [[[_sendButton wtr_bottomConstraint] toSecondViewBottom:self] addToView:self];
 }
 
 - (void)setupCircleScoreViewWithViewController:(UIViewController *)viewController {

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController+Constraints.m
@@ -93,7 +93,14 @@
 
 - (void)setupQuestionViewConstraints {
   [self.questionView wtr_constraintWidthEqualSecondViewWidth:self.view];
-  [self.questionView wtr_constraintHeight:110];
+  self.constraintQuestionViewHeight = [NSLayoutConstraint constraintWithItem:self.questionView
+                                                                   attribute:NSLayoutAttributeHeight
+                                                                   relatedBy:NSLayoutRelationEqual
+                                                                      toItem:nil
+                                                                   attribute:NSLayoutAttributeNotAnAttribute
+                                                                  multiplier:1
+                                                                    constant:110];
+  [self.questionView addConstraint:self.constraintQuestionViewHeight];
   [[[self.questionView wtr_centerXConstraint] toSecondViewCenterX:self.modalView] addToView:self.modalView];
   self.constraintQuestionTopToModalTop = [[self.questionView wtr_topConstraint] toSecondViewTop:self.modalView];
   [self.constraintQuestionTopToModalTop addToView:self.modalView];

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.h
@@ -45,6 +45,7 @@
 @property (nonatomic, strong) NSLayoutConstraint *constraintQuestionTopToModalTop;
 @property (nonatomic, strong) NSLayoutConstraint *constraintModalHeight;
 @property (nonatomic, strong) NSLayoutConstraint *constraintFeedbackViewHeight;
+@property (nonatomic, strong) NSLayoutConstraint *constraintQuestionViewHeight;
 @property (nonatomic, strong) NSLayoutConstraint *socialShareViewHeightConstraint;
 @property (nonatomic, strong) UILabel *finalThankYouLabel;
 

--- a/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
+++ b/WootricSDK/WootricSDK/WTRiPADSurveyViewController.m
@@ -150,15 +150,30 @@
 - (void)updateConstraints {
   _constraintModalHeight.constant = 215;
   _constraintFeedbackViewHeight.constant = 100;
+  _constraintQuestionViewHeight.constant = 110;
   _constraintQuestionTopToModalTop.constant = 50;
-  if ([_feedbackView numberOfRows] > 0) {
-    int numberOfRows = [_feedbackView numberOfRows];
+
+  NSDictionary *driverPicklistSettings = [_settings driverPicklistSettingsForScore:_currentScore];
+  int numberOfRows = [_feedbackView numberOfRows];
+
+  if (numberOfRows > 0 && [[_settings driverPicklistAnswersForScore:_currentScore] count] > 0) {
     _constraintModalHeight.constant += numberOfRows * 43;
     _constraintFeedbackViewHeight.constant += numberOfRows * 43;
     _constraintQuestionTopToModalTop.constant += numberOfRows * 43;
+
+    if (driverPicklistSettings[@"dpl_hide_open_ended"] && [driverPicklistSettings[@"dpl_hide_open_ended"] intValue] == 1) {
+      _constraintFeedbackViewHeight.constant = 51 + numberOfRows * 43;
+      _constraintQuestionTopToModalTop.constant = numberOfRows * 43;
+      _constraintQuestionViewHeight.constant += numberOfRows * 43;
+      [_questionView showSendButton:true];
+    } else {
+      [_questionView showSendButton:false];
+    }
+  } else {
+    [_questionView showSendButton:false];
   }
   _constraintTopToModalTop.constant = self.view.frame.size.height - _constraintModalHeight.constant;
-  
+
   [UIView animateWithDuration:0.2 animations:^{
     [self.view layoutIfNeeded];
   } completion:^(BOOL finished) {
@@ -348,7 +363,9 @@
     modalPosition = bounds.size.height - self->_modalView.frame.size.height;
 
     self->_constraintTopToModalTop.constant = modalPosition;
-    [self updateConstraints];
+    if (!self->_feedbackView.hidden) {
+      [self updateConstraints];
+    }
   } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
     if (self->_keyboardHeight == 0) {
       [self->_scrollView setContentOffset:CGPointMake(0, self->_keyboardHeight) animated:YES];


### PR DESCRIPTION
Add option to hide open-ended text box when Picklist is active.

## Changes

- Add support for `dpl_hide_open_ended` setting for iPhone & iPad