### PR TITLE
Define the `viewController` as weak in `WTRQuestionView`.

### DIFF
--- a/WootricSDK/WootricSDK/WTRQuestionView.m
+++ b/WootricSDK/WootricSDK/WTRQuestionView.m
@@ -38,7 +38,7 @@
 @property (nonatomic, strong) WTRSlider *scoreSlider;
 @property (nonatomic, strong) WTRScoreView *scoreLabel;
 @property (nonatomic, strong) WTRSettings *settings;
-@property (nonatomic, strong) WTRSurveyViewController *viewController;
+@property (nonatomic, weak) WTRSurveyViewController *viewController;
 
 @end
 


### PR DESCRIPTION
The `WTRSurveyViewController` has a strong reference to the `WTRQuestionView *questionView`. Since the controller is the owner of the view, the back reference from the view to the controller should be weak to break the retain cycle.